### PR TITLE
plan(v5): add adoption and reliability roadmap modules

### DIFF
--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -44,6 +44,12 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - [ ] `gx tui` provides interactive terminal UI for project navigation
 - [ ] `gx tutorial` walks new users through features interactively
 
+### v5 — Adoption & Reliability (Draft)
+
+- [ ] One-command install + GitHub release binaries for low-friction onboarding
+- [ ] Shell portability beyond zsh (bash + fish support)
+- [ ] `gx doctor` and index diagnostics/stats for trust at scale
+
 ## Constraints
 
 - TypeScript + Bun only (no Go, no Node)
@@ -69,6 +75,9 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 | [Templates](./modules/12-templates.aps.md) | Create new projects from template repositories | Future | v4 | Clone, Index |
 | [Interactive TUI](./modules/13-tui.aps.md) | Keyboard-navigable interactive terminal dashboard | Future | v4 | Dashboard, Tracking |
 | [Tutorial](./modules/14-tutorial.aps.md) | Interactive walkthrough teaching gx features | Future | v4 | All stable modules |
+| [Distribution & Install UX](./modules/15-distribution.aps.md) | Release binaries, installer, and doctor flow for easy adoption | Draft | v5 | CLI |
+| [Shell Portability](./modules/16-shell-portability.aps.md) | Bash/fish integration and completion parity | Draft | v5 | Shell Plugin, CLI |
+| [Index Reliability & Observability](./modules/17-index-observability.aps.md) | Index diagnostics, stats, and scan telemetry | Draft | v5 | Index, Tracking |
 
 ## Risks
 

--- a/plans/modules/15-distribution.aps.md
+++ b/plans/modules/15-distribution.aps.md
@@ -1,0 +1,33 @@
+# Distribution & Install UX
+
+| Field | Value |
+|-------|-------|
+| Module ID | DISTRIBUTION |
+| Status | Draft |
+| Version | v5 |
+| Owner | @joshuaboys |
+| Depends On | CLI |
+
+## Purpose
+
+Make `gx` trivial to install and upgrade for first-time users.
+
+## Outcomes
+
+- Prebuilt binaries published on GitHub Releases for Linux/macOS
+- Single-command install script
+- `gx doctor` verifies runtime, shell plugin, config paths
+
+## Work Items
+
+### DIST-001: Release artifacts
+- Build and upload precompiled binaries in CI
+- Publish checksums and release notes
+
+### DIST-002: One-line installer
+- `curl | bash` installer with platform detection
+- Safe fallback instructions when unsupported
+
+### DIST-003: Doctor command
+- Validate PATH, plugin wiring, config/index health
+- Return actionable fix suggestions

--- a/plans/modules/15-distribution.aps.md
+++ b/plans/modules/15-distribution.aps.md
@@ -1,33 +1,44 @@
 # Distribution & Install UX
 
-| Field | Value |
-|-------|-------|
-| Module ID | DISTRIBUTION |
-| Status | Draft |
-| Version | v5 |
-| Owner | @joshuaboys |
-| Depends On | CLI |
+| ID | Owner | Status |
+|----|-------|--------|
+| DIST | @joshuaboys | Draft |
+
+- Version: v5
+- Depends on: CLI
 
 ## Purpose
 
 Make `gx` trivial to install and upgrade for first-time users.
 
-## Outcomes
+## In Scope
 
 - Prebuilt binaries published on GitHub Releases for Linux/macOS
-- Single-command install script
-- `gx doctor` verifies runtime, shell plugin, config paths
+- Simple, cross-platform install command that downloads a binary, verifies its checksum/signature, then installs
+- Clearly documented trust model (who signs releases, how checksums are distributed, how users verify)
+- `gx doctor` command to verify runtime, shell plugin, config paths
 
-## Work Items
+## Out of Scope
 
-### DIST-001: Release artifacts
-- Build and upload precompiled binaries in CI
-- Publish checksums and release notes
+- Package manager submissions (Homebrew, AUR, etc.) — deferred to a future module
+- Auto-update mechanism
 
-### DIST-002: One-line installer
-- `curl | bash` installer with platform detection
-- Safe fallback instructions when unsupported
+## Interfaces
 
-### DIST-003: Doctor command
-- Validate PATH, plugin wiring, config/index health
-- Return actionable fix suggestions
+**Depends on:**
+
+- CLI — command surface
+
+**Exposes:**
+
+- `gx doctor` — health check command (index diagnostics contributed by IDXOB module)
+
+## Ready Checklist
+
+- [ ] Purpose and scope are clear
+- [ ] Dependencies identified
+- [ ] At least one task defined
+
+## Tasks
+
+*No tasks yet — module is Draft*

--- a/plans/modules/16-shell-portability.aps.md
+++ b/plans/modules/16-shell-portability.aps.md
@@ -1,30 +1,43 @@
 # Shell Portability
 
-| Field | Value |
-|-------|-------|
-| Module ID | SHELL |
-| Status | Draft |
-| Version | v5 |
-| Owner | @joshuaboys |
-| Depends On | Shell Plugin, CLI |
+| ID | Owner | Status |
+|----|-------|--------|
+| SHELL | @joshuaboys | Draft |
+
+- Version: v5
+- Depends on: Shell Plugin, CLI
 
 ## Purpose
 
 Expand `gx` beyond oh-my-zsh to increase adoption.
 
-## Outcomes
+## In Scope
 
 - Native shell integration for bash and fish
 - Cross-shell completion support
-- Consistent `gx jump` UX across shells
+- Consistent `gx <name>` UX for jumping across shells
 
-## Work Items
+## Out of Scope
 
-### SHELL-001: Bash integration
-- Completion + jump function + plugin docs
+- Changes to core `gx` behavior that are not related to shell portability or integration
 
-### SHELL-002: Fish integration
-- Completion + function wrappers
+## Interfaces
 
-### SHELL-003: Compatibility matrix
-- Test shell behavior in CI and document differences
+**Depends on:**
+
+- Shell Plugin — existing zsh plugin as reference
+- CLI — command surface
+
+**Exposes:**
+
+- Shell plugins for bash and fish
+
+## Ready Checklist
+
+- [ ] Purpose and scope are clear
+- [ ] Dependencies identified
+- [ ] At least one task defined
+
+## Tasks
+
+*No tasks yet — module is Draft*

--- a/plans/modules/16-shell-portability.aps.md
+++ b/plans/modules/16-shell-portability.aps.md
@@ -1,0 +1,30 @@
+# Shell Portability
+
+| Field | Value |
+|-------|-------|
+| Module ID | SHELL |
+| Status | Draft |
+| Version | v5 |
+| Owner | @joshuaboys |
+| Depends On | Shell Plugin, CLI |
+
+## Purpose
+
+Expand `gx` beyond oh-my-zsh to increase adoption.
+
+## Outcomes
+
+- Native shell integration for bash and fish
+- Cross-shell completion support
+- Consistent `gx jump` UX across shells
+
+## Work Items
+
+### SHELL-001: Bash integration
+- Completion + jump function + plugin docs
+
+### SHELL-002: Fish integration
+- Completion + function wrappers
+
+### SHELL-003: Compatibility matrix
+- Test shell behavior in CI and document differences

--- a/plans/modules/17-index-observability.aps.md
+++ b/plans/modules/17-index-observability.aps.md
@@ -1,0 +1,30 @@
+# Index Reliability & Observability
+
+| Field | Value |
+|-------|-------|
+| Module ID | INDEXOBS |
+| Status | Draft |
+| Version | v5 |
+| Owner | @joshuaboys |
+| Depends On | Index, Tracking |
+
+## Purpose
+
+Increase trust in `gx` behavior at scale with diagnostics and stats.
+
+## Outcomes
+
+- `gx index stats` (size, collisions, stale paths, last rebuild)
+- `gx doctor` index diagnostics (missing dirs, broken links, invalid entries)
+- Optional debug output and timing telemetry for scans/rebuilds
+
+## Work Items
+
+### INDEXOBS-001: Stats command
+- Human + machine-readable index statistics
+
+### INDEXOBS-002: Diagnostics
+- Detect and report index/path inconsistency with fix hints
+
+### INDEXOBS-003: Scan telemetry
+- Capture scan duration and bottlenecks for large project trees

--- a/plans/modules/17-index-observability.aps.md
+++ b/plans/modules/17-index-observability.aps.md
@@ -1,30 +1,44 @@
 # Index Reliability & Observability
 
-| Field | Value |
-|-------|-------|
-| Module ID | INDEXOBS |
-| Status | Draft |
-| Version | v5 |
-| Owner | @joshuaboys |
-| Depends On | Index, Tracking |
+| ID | Owner | Status |
+|----|-------|--------|
+| IDXOB | @joshuaboys | Draft |
+
+- Version: v5
+- Depends on: Index, Tracking
 
 ## Purpose
 
-Increase trust in `gx` behavior at scale with diagnostics and stats.
+Increase trust in `gx` behaviour at scale with diagnostics and stats.
 
-## Outcomes
+## In Scope
 
 - `gx index stats` (size, collisions, stale paths, last rebuild)
-- `gx doctor` index diagnostics (missing dirs, broken links, invalid entries)
+- Index diagnostics checks contributed to global `gx doctor` (missing dirs, broken links, invalid entries)
 - Optional debug output and timing telemetry for scans/rebuilds
 
-## Work Items
+## Out of Scope
 
-### INDEXOBS-001: Stats command
-- Human + machine-readable index statistics
+- The `gx doctor` command itself (owned by DIST module); this module contributes index-specific checks
 
-### INDEXOBS-002: Diagnostics
-- Detect and report index/path inconsistency with fix hints
+## Interfaces
 
-### INDEXOBS-003: Scan telemetry
-- Capture scan duration and bottlenecks for large project trees
+**Depends on:**
+
+- Index — index data structures
+- Tracking — activity data for telemetry
+
+**Exposes:**
+
+- Index diagnostics checks (consumed by `gx doctor`)
+- `gx index stats` subcommand
+
+## Ready Checklist
+
+- [ ] Purpose and scope are clear
+- [ ] Dependencies identified
+- [ ] At least one task defined
+
+## Tasks
+
+*No tasks yet — module is Draft*


### PR DESCRIPTION
## Summary
- add v5 Adoption & Reliability track to APS index
- add Distribution & Install UX module
- add Shell Portability module (bash/fish)
- add Index Reliability & Observability module

## Why
These are the highest-leverage follow-ups for gx adoption and trust after core UX: easier install/distribution, broader shell support, and better diagnostics at scale.
