### PR TITLE
feat: universal shell-init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,39 +9,62 @@ A fast git project manager for cloning, navigating, and organising repositories.
 - **Fuzzy matching** --- misspell a project name and gx suggests the closest match
 - **Editor integration** --- `gx open <name>` opens a project in your preferred editor
 - **Agent scaffolding** --- `gx init` scaffolds `.claude/` configuration for AI-assisted development
-- **Shell integration** --- oh-my-zsh plugin for `cd`, completions, and shell functions
+- **Shell integration** --- native support for zsh, bash, and fish with completions
 
 ## Install
 
 ### Prerequisites
 
 - [Bun](https://bun.sh) v1.0+
-- zsh with [oh-my-zsh](https://ohmyz.sh)
 
 ### Build and install
 
 ```sh
 git clone https://github.com/joshuaboys/gx
 cd gx
-
-# Build the binary
+bun install
 bun run build
-
-# Install the zsh plugin
-ln -s "$(pwd)/plugin" ~/.oh-my-zsh/custom/plugins/gx
 ```
 
-Add `gx` to your oh-my-zsh plugins in `~/.zshrc`:
+Copy the binary somewhere on your `PATH`:
 
 ```sh
-plugins=(git gx)
+cp gx ~/.local/bin/
 ```
 
-Reload your shell:
+### Shell integration
+
+Add one line to your shell config to enable `cd` on clone/jump and tab completion:
+
+**zsh** (`~/.zshrc`):
+```sh
+eval "$(gx shell-init)"
+```
+
+**bash** (`~/.bashrc`):
+```sh
+eval "$(gx shell-init)"
+```
+
+**fish** (`~/.config/fish/conf.d/gx.fish`):
+```fish
+gx shell-init | source
+```
+
+Reload your shell and you're good to go.
+
+<details>
+<summary>oh-my-zsh (legacy)</summary>
+
+If you already use gx as an oh-my-zsh plugin, it still works:
 
 ```sh
-source ~/.zshrc
+ln -s /path/to/gx/plugin ~/.oh-my-zsh/custom/plugins/gx
+# add gx to plugins=(...) in ~/.zshrc
 ```
+
+The plugin file now delegates to `gx shell-init` internally.
+</details>
 
 ## Usage
 

--- a/plugin/gx.plugin.zsh
+++ b/plugin/gx.plugin.zsh
@@ -1,66 +1,16 @@
-# gx — git project manager shell integration
-# Install: symlink or copy to ~/.oh-my-zsh/custom/plugins/gx/
+# gx — git project manager (oh-my-zsh compatibility shim)
+# Prefer adding to ~/.zshrc directly: eval "$(gx shell-init)"
+#
+# This file exists for users who already have gx installed as an
+# oh-my-zsh custom plugin. It delegates to `gx shell-init zsh`.
 
-# Capture plugin directory at source time (${0:A:h} only works at top level)
 _GX_PLUGIN_DIR="${0:A:h}"
 
-# Run the gx binary directly without eval — eliminates command injection risk
-_gx_run() {
-    if (( $+commands[gx] )); then
-        command gx "$@"
-    elif [ -f "$_GX_PLUGIN_DIR/../gx" ] && [ -x "$_GX_PLUGIN_DIR/../gx" ]; then
-        "$_GX_PLUGIN_DIR/../gx" "$@"
-    else
-        bun run "$_GX_PLUGIN_DIR/../src/index.ts" "$@"
-    fi
-}
-
-gx() {
-    case "$1" in
-        clone)
-            # stdout = path (machine-readable), stderr = progress (human-readable)
-            local output
-            output=$(_gx_run clone "${@:2}")
-            if [ -n "$output" ] && [ -d "$output" ]; then
-                cd "$output"
-            fi
-            ;;
-        ls|rebuild|config|open|init|--help|-h|--version|-v)
-            _gx_run "$@"
-            ;;
-        resolve)
-            _gx_run "$@"
-            ;;
-        "")
-            _gx_run --help
-            ;;
-        *)
-            # Default: jump to project (with fuzzy matching fallback)
-            # stdout = path, stderr = fuzzy match info
-            local target
-            target=$(_gx_run resolve "$1")
-            if [ -n "$target" ] && [ -d "$target" ]; then
-                cd "$target"
-            else
-                return 1
-            fi
-            ;;
-    esac
-}
-
-# Tab completion
-_gx() {
-    local -a commands projects
-    commands=(clone ls rebuild config resolve open init --help --version)
-
-    if (( CURRENT == 2 )); then
-        # First arg: commands + project names
-        projects=($(_gx_run resolve --list 2>/dev/null))
-        compadd "${commands[@]}" "${projects[@]}"
-    elif (( CURRENT == 3 )) && [[ "${words[2]}" == "config" ]]; then
-        compadd set
-    elif (( CURRENT == 4 )) && [[ "${words[2]}" == "config" ]] && [[ "${words[3]}" == "set" ]]; then
-        compadd projectDir defaultHost structure shallow similarityThreshold editor
-    fi
-}
-(( $+functions[compdef] )) && compdef _gx gx
+# Find the gx binary and eval its shell integration
+if (( $+commands[gx] )); then
+    eval "$(command gx shell-init zsh)"
+elif [ -f "$_GX_PLUGIN_DIR/../gx" ] && [ -x "$_GX_PLUGIN_DIR/../gx" ]; then
+    eval "$("$_GX_PLUGIN_DIR/../gx" shell-init zsh)"
+else
+    eval "$(bun run "$_GX_PLUGIN_DIR/../src/index.ts" shell-init zsh)"
+fi

--- a/src/commands/shell-init.ts
+++ b/src/commands/shell-init.ts
@@ -1,0 +1,179 @@
+const SUPPORTED_SHELLS = ["zsh", "bash", "fish"] as const;
+type Shell = (typeof SUPPORTED_SHELLS)[number];
+
+function detectShell(): Shell | null {
+  const shell = process.env.SHELL ?? "";
+  if (shell.endsWith("/zsh")) return "zsh";
+  if (shell.endsWith("/bash")) return "bash";
+  if (shell.endsWith("/fish")) return "fish";
+  return null;
+}
+
+function zshInit(): string {
+  return `# gx — git project manager shell integration
+# Add to ~/.zshrc: eval "$(gx shell-init)"
+
+gx() {
+    case "$1" in
+        clone)
+            local output
+            output=$(command gx clone "\${@:2}")
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            fi
+            ;;
+        ls|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
+            command gx "$@"
+            ;;
+        resolve)
+            command gx "$@"
+            ;;
+        "")
+            command gx --help
+            ;;
+        *)
+            local target
+            target=$(command gx resolve "$1")
+            if [ -n "$target" ] && [ -d "$target" ]; then
+                cd "$target"
+            else
+                return 1
+            fi
+            ;;
+    esac
+}
+
+# Tab completion
+_gx() {
+    local -a commands projects
+    commands=(clone ls rebuild config resolve open init shell-init --help --version)
+
+    if (( CURRENT == 2 )); then
+        projects=($(command gx resolve --list 2>/dev/null))
+        compadd "\${commands[@]}" "\${projects[@]}"
+    elif (( CURRENT == 3 )) && [[ "\${words[2]}" == "config" ]]; then
+        compadd set
+    elif (( CURRENT == 4 )) && [[ "\${words[2]}" == "config" ]] && [[ "\${words[3]}" == "set" ]]; then
+        compadd projectDir defaultHost structure shallow similarityThreshold editor
+    fi
+}
+(( $+functions[compdef] )) && compdef _gx gx`;
+}
+
+function bashInit(): string {
+  return `# gx — git project manager shell integration
+# Add to ~/.bashrc: eval "$(gx shell-init)"
+
+gx() {
+    case "$1" in
+        clone)
+            local output
+            output=$(command gx clone "\${@:2}")
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            fi
+            ;;
+        ls|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
+            command gx "$@"
+            ;;
+        resolve)
+            command gx "$@"
+            ;;
+        "")
+            command gx --help
+            ;;
+        *)
+            local target
+            target=$(command gx resolve "$1")
+            if [ -n "$target" ] && [ -d "$target" ]; then
+                cd "$target"
+            else
+                return 1
+            fi
+            ;;
+    esac
+}
+
+# Tab completion
+_gx_completions() {
+    local cur="\${COMP_WORDS[COMP_CWORD]}"
+    local prev="\${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [ "\$COMP_CWORD" -eq 1 ]; then
+        local commands="clone ls rebuild config resolve open init shell-init --help --version"
+        local projects
+        projects=$(command gx resolve --list 2>/dev/null)
+        COMPREPLY=($(compgen -W "$commands $projects" -- "$cur"))
+    elif [ "\$COMP_CWORD" -eq 2 ] && [ "$prev" = "config" ]; then
+        COMPREPLY=($(compgen -W "set" -- "$cur"))
+    elif [ "\$COMP_CWORD" -eq 3 ] && [ "\${COMP_WORDS[1]}" = "config" ] && [ "$prev" = "set" ]; then
+        COMPREPLY=($(compgen -W "projectDir defaultHost structure shallow similarityThreshold editor" -- "$cur"))
+    fi
+}
+complete -F _gx_completions gx`;
+}
+
+function fishInit(): string {
+  return `# gx — git project manager shell integration
+# Add to ~/.config/fish/conf.d/gx.fish: gx shell-init | source
+
+function gx
+    switch $argv[1]
+        case clone
+            set -l output (command gx clone $argv[2..])
+            if test -n "$output" -a -d "$output"
+                cd $output
+            end
+        case ls rebuild config open init shell-init --help -h --version -v resolve
+            command gx $argv
+        case ''
+            command gx --help
+        case '*'
+            set -l target (command gx resolve $argv[1])
+            if test -n "$target" -a -d "$target"
+                cd $target
+            else
+                return 1
+            end
+    end
+end
+
+# Tab completion
+complete -c gx -f
+complete -c gx -n "__fish_use_subcommand" -a "clone ls rebuild config resolve open init shell-init --help --version"
+complete -c gx -n "__fish_use_subcommand" -a "(command gx resolve --list 2>/dev/null)"
+complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
+complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"`;
+}
+
+export function shellInit(shellArg?: string): void {
+  let shell: Shell | null;
+
+  if (shellArg) {
+    if (!SUPPORTED_SHELLS.includes(shellArg as Shell)) {
+      console.error(`Unsupported shell: ${shellArg}`);
+      console.error(`Supported shells: ${SUPPORTED_SHELLS.join(", ")}`);
+      process.exit(1);
+    }
+    shell = shellArg as Shell;
+  } else {
+    shell = detectShell();
+    if (!shell) {
+      console.error("Could not detect shell from $SHELL");
+      console.error(`Specify one explicitly: gx shell-init <${SUPPORTED_SHELLS.join("|")}>`);
+      process.exit(1);
+    }
+  }
+
+  switch (shell) {
+    case "zsh":
+      console.log(zshInit());
+      break;
+    case "bash":
+      console.log(bashInit());
+      break;
+    case "fish":
+      console.log(fishInit());
+      break;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { rebuild } from "./commands/rebuild.ts";
 import { showConfig, setConfig } from "./commands/config.ts";
 import { openProject } from "./commands/open.ts";
 import { initAgent } from "./commands/init.ts";
+import { shellInit } from "./commands/shell-init.ts";
 import pkg from "../package.json";
 
 const VERSION = pkg.version;
@@ -33,6 +34,7 @@ Usage:
   gx config                Show config
   gx config set <key> <v>  Set config value
   gx init                  Scaffold .claude/ agent config
+  gx shell-init [shell]    Print shell integration code
   gx resolve <name>        Resolve project name to path
   gx resolve --list        List all project names
 
@@ -109,6 +111,9 @@ Options:
       await initAgent(process.cwd(), { type, force });
       break;
     }
+    case "shell-init":
+      shellInit(args[1]);
+      break;
     case "resolve":
       if (args[1] === "--list") {
         await resolve("", indexPath, config, true);

--- a/tests/commands/shell-init.test.ts
+++ b/tests/commands/shell-init.test.ts
@@ -1,0 +1,124 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { shellInit } from "../../src/commands/shell-init.ts";
+
+// Capture stdout by temporarily replacing console.log
+function captureOutput(fn: () => void): string {
+  const lines: string[] = [];
+  const orig = console.log;
+  console.log = (...args: unknown[]) => lines.push(args.join(" "));
+  try {
+    fn();
+  } finally {
+    console.log = orig;
+  }
+  return lines.join("\n");
+}
+
+describe("shellInit", () => {
+  let origShell: string | undefined;
+  let origExit: typeof process.exit;
+
+  beforeEach(() => {
+    origShell = process.env.SHELL;
+    origExit = process.exit;
+  });
+
+  afterEach(() => {
+    if (origShell !== undefined) {
+      process.env.SHELL = origShell;
+    } else {
+      delete process.env.SHELL;
+    }
+    process.exit = origExit;
+  });
+
+  test("explicit zsh outputs zsh integration", () => {
+    const output = captureOutput(() => shellInit("zsh"));
+    expect(output).toContain("gx()");
+    expect(output).toContain("compdef _gx gx");
+    expect(output).toContain("command gx clone");
+  });
+
+  test("explicit bash outputs bash integration", () => {
+    const output = captureOutput(() => shellInit("bash"));
+    expect(output).toContain("gx()");
+    expect(output).toContain("complete -F _gx_completions gx");
+    expect(output).toContain("COMPREPLY");
+  });
+
+  test("explicit fish outputs fish integration", () => {
+    const output = captureOutput(() => shellInit("fish"));
+    expect(output).toContain("function gx");
+    expect(output).toContain("complete -c gx");
+    expect(output).toContain("__fish_use_subcommand");
+  });
+
+  test("auto-detects zsh from SHELL env", () => {
+    process.env.SHELL = "/bin/zsh";
+    const output = captureOutput(() => shellInit());
+    expect(output).toContain("compdef _gx gx");
+  });
+
+  test("auto-detects bash from SHELL env", () => {
+    process.env.SHELL = "/usr/bin/bash";
+    const output = captureOutput(() => shellInit());
+    expect(output).toContain("complete -F _gx_completions gx");
+  });
+
+  test("auto-detects fish from SHELL env", () => {
+    process.env.SHELL = "/usr/bin/fish";
+    const output = captureOutput(() => shellInit());
+    expect(output).toContain("complete -c gx");
+  });
+
+  test("unsupported shell exits with error", () => {
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error("exit");
+    }) as never;
+    expect(() => shellInit("powershell")).toThrow("exit");
+    expect(exitCode).toBe(1);
+  });
+
+  test("unknown SHELL env exits with error", () => {
+    process.env.SHELL = "/usr/bin/tcsh";
+    let exitCode: number | undefined;
+    process.exit = ((code: number) => {
+      exitCode = code;
+      throw new Error("exit");
+    }) as never;
+    expect(() => shellInit()).toThrow("exit");
+    expect(exitCode).toBe(1);
+  });
+
+  test("zsh output includes shell-init in command list", () => {
+    const output = captureOutput(() => shellInit("zsh"));
+    expect(output).toContain("shell-init");
+  });
+
+  test("bash output includes shell-init in command list", () => {
+    const output = captureOutput(() => shellInit("bash"));
+    expect(output).toContain("shell-init");
+  });
+
+  test("fish output includes shell-init in command list", () => {
+    const output = captureOutput(() => shellInit("fish"));
+    expect(output).toContain("shell-init");
+  });
+
+  test("zsh clone handler uses cd", () => {
+    const output = captureOutput(() => shellInit("zsh"));
+    expect(output).toContain('cd "$output"');
+  });
+
+  test("bash clone handler uses cd", () => {
+    const output = captureOutput(() => shellInit("bash"));
+    expect(output).toContain('cd "$output"');
+  });
+
+  test("fish clone handler uses cd", () => {
+    const output = captureOutput(() => shellInit("fish"));
+    expect(output).toContain("cd $output");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `gx shell-init [zsh|bash|fish]` command that outputs shell integration code for any supported shell
- Auto-detects shell from `$SHELL` env var, or accepts explicit argument
- Supports zsh (compdef), bash (complete -F), and fish (complete -c) with full tab completion
- Oh-my-zsh plugin preserved as a thin compat shim delegating to `shell-init`
- README updated with universal install instructions; oh-my-zsh in collapsible legacy section

## Test plan

- [x] 14 new tests covering all three shells, auto-detection, error cases
- [x] All 136 tests passing
- [x] `tsc --noEmit` clean
- [ ] Manual: `eval "$(gx shell-init zsh)"` in a fresh zsh session
- [ ] Manual: `eval "$(gx shell-init bash)"` in a bash session
- [ ] Manual: `gx shell-init fish | source` in a fish session

🤖 Generated with [Claude Code](https://claude.com/claude-code)