### PR TITLE
feat: add curl installer and user-centric README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to gx
+
+## Prerequisites
+
+- [Bun](https://bun.sh) v1.0+
+- Git
+
+## Setup
+
+```sh
+git clone https://github.com/joshuaboys/gx
+cd gx
+bun install
+```
+
+## Development
+
+Run from source (no build step):
+
+```sh
+bun run dev
+```
+
+Build the standalone binary:
+
+```sh
+bun run build
+```
+
+Run tests:
+
+```sh
+bun test
+```
+
+## Project structure
+
+```
+src/
+  index.ts              # CLI entry point and command router
+  commands/
+    clone.ts            # gx clone
+    config.ts           # gx config
+    init.ts             # gx init (.claude/ scaffolding)
+    ls.ts               # gx ls
+    open.ts             # gx open
+    rebuild.ts          # gx rebuild
+    resolve.ts          # gx <name> (project lookup)
+    shell-init.ts       # gx shell-init (shell integration generator)
+  lib/
+    config.ts           # Config file management (~/.config/gx/config.json)
+    detect.ts           # Project type detection
+    fuzzy.ts            # Fuzzy matching for project names
+    index.ts            # Lib barrel exports
+    path.ts             # Path resolution and project indexing
+    templates.ts        # .claude/ scaffolding templates
+    url.ts              # Git URL parsing
+plugin/
+  gx.plugin.zsh        # oh-my-zsh compatibility shim
+install.sh              # Curl installer
+```
+
+## Conventions
+
+- TypeScript, built with Bun
+- No external runtime dependencies (compiles to standalone binary)
+- Shell integration generated at runtime via `gx shell-init`
+- Conventional commits (`feat:`, `fix:`, `docs:`, etc.)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gx
 
-A fast git project manager for cloning, navigating, and organising repositories.
+A fast git project manager for cloning, navigating, and organizing repositories.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,30 @@
 # gx
 
-A fast git project manager for cloning, navigating, and organising repositories. Built with TypeScript and Bun.
-
-## Features
-
-- **Organised cloning** --- `gx clone user/repo` clones to a structured directory and cd's into it
-- **Instant navigation** --- `gx <name>` jumps to any indexed project with tab completion
-- **Fuzzy matching** --- misspell a project name and gx suggests the closest match
-- **Editor integration** --- `gx open <name>` opens a project in your preferred editor
-- **Agent scaffolding** --- `gx init` scaffolds `.claude/` configuration for AI-assisted development
-- **Shell integration** --- native support for zsh, bash, and fish with completions
+A fast git project manager for cloning, navigating, and organising repositories.
 
 ## Install
 
-### Prerequisites
+```sh
+curl -fsSL https://raw.githubusercontent.com/joshuaboys/gx/main/install.sh | sh
+```
 
-- [Bun](https://bun.sh) v1.0+
+This downloads (or builds) the `gx` binary, puts it on your PATH, and sets up shell integration with tab completion. Supports zsh, bash, and fish.
 
-### Build and install
+<details>
+<summary>Manual install</summary>
+
+Requires [Bun](https://bun.sh) v1.0+.
 
 ```sh
 git clone https://github.com/joshuaboys/gx
 cd gx
-bun install
-bun run build
-```
-
-Copy the binary somewhere on your `PATH`:
-
-```sh
+bun install && bun run build
 cp gx ~/.local/bin/
 ```
 
-### Shell integration
+Add shell integration to your config file:
 
-Add one line to your shell config to enable `cd` on clone/jump and tab completion:
-
-**zsh** (`~/.zshrc`):
-```sh
-eval "$(gx shell-init)"
-```
-
-**bash** (`~/.bashrc`):
+**zsh** (`~/.zshrc`) / **bash** (`~/.bashrc`):
 ```sh
 eval "$(gx shell-init)"
 ```
@@ -50,8 +33,7 @@ eval "$(gx shell-init)"
 ```fish
 gx shell-init | source
 ```
-
-Reload your shell and you're good to go.
+</details>
 
 <details>
 <summary>oh-my-zsh (legacy)</summary>
@@ -113,7 +95,7 @@ gx init --force            # overwrite existing .claude/
 
 Creates `.claude/CLAUDE.md` and `.claude/commands/` with plan and review slash commands. Supports project types: `typescript-bun`, `typescript-node`, `rust`, `go`, `python`, `generic`.
 
-### Configuration
+## Configuration
 
 ```sh
 gx config                         # show current config
@@ -126,15 +108,7 @@ gx config set editor code         # set default editor
 
 Config is stored at `~/.config/gx/config.json`.
 
-### Rebuild index
-
-```sh
-gx rebuild
-```
-
-Rescans the project directory and rebuilds the project index.
-
-## Directory structure
+### Directory structure
 
 By default, gx uses the `owner` structure:
 
@@ -160,13 +134,25 @@ Set `structure` to `host` for host-prefixed layout:
   gitlab.com/owner/other-repo/
 ```
 
-## Development
+### Rebuild index
 
 ```sh
-bun test           # run tests
-bun run dev        # run from source
-bun run build      # compile binary
+gx rebuild
 ```
+
+Rescans the project directory and rebuilds the project index.
+
+## Uninstall
+
+```sh
+rm ~/.local/bin/gx
+```
+
+Remove the `# gx` block from your shell config file (`~/.zshrc`, `~/.bashrc`, or `~/.config/fish/conf.d/gx.fish`).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gx
 
-A fast git project manager for cloning, navigating, and organizing repositories.
+A fast git project manager for cloning, navigating, and organising repositories.
 
 ## Install
 

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,7 @@ setup_shell() {
   rc_file=$(shell_rc_file "$shell")
 
   if [ -z "$rc_file" ]; then
-    warn "Unrecognized shell ($shell). Add shell integration manually:"
+    warn "Unrecognised shell ($shell). Add shell integration manually:"
     echo '  eval "$(gx shell-init)"'
     return
   fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,207 @@
+#!/bin/sh
+set -e
+
+# gx installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/joshuaboys/gx/main/install.sh | sh
+
+REPO="joshuaboys/gx"
+INSTALL_DIR="$HOME/.local/bin"
+GX_BIN="$INSTALL_DIR/gx"
+
+# --- helpers ---
+
+info() { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$1"; }
+error() { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
+
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux*)  echo "linux" ;;
+    Darwin*) echo "darwin" ;;
+    *)       error "Unsupported OS: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)  echo "x64" ;;
+    aarch64|arm64) echo "aarch64" ;;
+    *)             error "Unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+detect_shell() {
+  basename "${SHELL:-/bin/sh}"
+}
+
+shell_rc_file() {
+  case "$1" in
+    zsh)  echo "$HOME/.zshrc" ;;
+    bash) echo "$HOME/.bashrc" ;;
+    fish) echo "$HOME/.config/fish/conf.d/gx.fish" ;;
+    *)    echo "" ;;
+  esac
+}
+
+# --- install strategies ---
+
+try_prebuilt() {
+  local os="$1" arch="$2"
+  local asset="gx-${os}-${arch}"
+  local url="https://github.com/${REPO}/releases/latest/download/${asset}"
+
+  info "Checking for prebuilt binary ($os-$arch)..."
+  local http_code
+  if command_exists curl; then
+    http_code=$(curl -sL -o /dev/null -w "%{http_code}" "$url" 2>/dev/null) || http_code="000"
+  elif command_exists wget; then
+    http_code=$(wget --spider -S "$url" 2>&1 | grep "HTTP/" | tail -1 | awk '{print $2}') || http_code="000"
+  else
+    return 1
+  fi
+
+  if [ "$http_code" != "200" ]; then
+    info "No prebuilt binary available, building from source..."
+    return 1
+  fi
+
+  info "Downloading prebuilt binary..."
+  mkdir -p "$INSTALL_DIR"
+  if command_exists curl; then
+    curl -fsSL "$url" -o "$GX_BIN"
+  else
+    wget -qO "$GX_BIN" "$url"
+  fi
+  chmod +x "$GX_BIN"
+  return 0
+}
+
+build_from_source() {
+  # Ensure bun is available
+  if ! command_exists bun; then
+    info "Bun not found, installing..."
+    if command_exists curl; then
+      curl -fsSL https://bun.sh/install | bash
+    elif command_exists wget; then
+      wget -qO- https://bun.sh/install | bash
+    else
+      error "Need curl or wget to install Bun"
+    fi
+    # Source bun into current session
+    export BUN_INSTALL="$HOME/.bun"
+    export PATH="$BUN_INSTALL/bin:$PATH"
+    if ! command_exists bun; then
+      error "Bun installation failed"
+    fi
+  fi
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  info "Cloning gx..."
+  if command_exists git; then
+    git clone --depth 1 "https://github.com/${REPO}.git" "$tmpdir/gx" 2>/dev/null
+  else
+    error "Git is required to build from source"
+  fi
+
+  info "Building..."
+  cd "$tmpdir/gx"
+  bun install --frozen-lockfile 2>/dev/null || bun install
+  bun run build
+
+  mkdir -p "$INSTALL_DIR"
+  cp gx "$GX_BIN"
+  chmod +x "$GX_BIN"
+  cd - >/dev/null
+}
+
+# --- shell integration ---
+
+setup_shell() {
+  local shell rc_file init_line marker
+  shell=$(detect_shell)
+  rc_file=$(shell_rc_file "$shell")
+
+  if [ -z "$rc_file" ]; then
+    warn "Unrecognised shell ($shell). Add shell integration manually:"
+    echo '  eval "$(gx shell-init)"'
+    return
+  fi
+
+  # Fish uses different syntax
+  if [ "$shell" = "fish" ]; then
+    init_line='gx shell-init | source'
+  else
+    init_line='eval "$(gx shell-init)"'
+  fi
+
+  marker="# gx"
+
+  # Already configured?
+  if [ -f "$rc_file" ] && grep -qF "$marker" "$rc_file" 2>/dev/null; then
+    info "Shell integration already in $rc_file"
+    return
+  fi
+
+  # Create parent dirs for fish
+  mkdir -p "$(dirname "$rc_file")"
+
+  printf '\n%s\n%s\n' "$marker" "$init_line" >> "$rc_file"
+  info "Added shell integration to $rc_file"
+}
+
+# --- PATH check ---
+
+ensure_path() {
+  case ":$PATH:" in
+    *":$INSTALL_DIR:"*) return ;;
+  esac
+
+  warn "$INSTALL_DIR is not on your PATH"
+
+  local shell rc_file
+  shell=$(detect_shell)
+  rc_file=$(shell_rc_file "$shell")
+
+  if [ -n "$rc_file" ] && [ -f "$rc_file" ]; then
+    if ! grep -qF "$INSTALL_DIR" "$rc_file" 2>/dev/null; then
+      if [ "$shell" = "fish" ]; then
+        printf '\nfish_add_path %s\n' "$INSTALL_DIR" >> "$rc_file"
+      else
+        printf '\nexport PATH="%s:$PATH"\n' "$INSTALL_DIR" >> "$rc_file"
+      fi
+      info "Added $INSTALL_DIR to PATH in $rc_file"
+    fi
+  else
+    echo "  Add this to your shell config:"
+    echo "    export PATH=\"$INSTALL_DIR:\$PATH\""
+  fi
+}
+
+# --- main ---
+
+main() {
+  info "Installing gx..."
+
+  local os arch
+  os=$(detect_os)
+  arch=$(detect_arch)
+
+  if ! try_prebuilt "$os" "$arch"; then
+    build_from_source
+  fi
+
+  ensure_path
+  setup_shell
+
+  echo ""
+  info "gx installed to $GX_BIN"
+  info "Restart your shell or run: exec \$SHELL"
+  echo ""
+}
+
+main

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ build_from_source() {
   info "Building..."
   cd "$tmpdir/gx"
   bun install --frozen-lockfile || bun install || error "bun install failed"
-  bun run build
+  bun run build || error "bun build failed"
 
   mkdir -p "$INSTALL_DIR"
   cp gx "$GX_BIN"


### PR DESCRIPTION
## Summary

- Add `install.sh` for one-liner installation: `curl -fsSL .../install.sh | sh`
  - Tries prebuilt binary from GitHub Releases first, falls back to source build
  - Auto-installs Bun if needed for source builds
  - Installs to `~/.local/bin/`, ensures PATH, configures shell integration
- Rewrite README to be user-focused — curl install front and center, manual install in collapsible details
- Move development docs to `CONTRIBUTING.md`
- Add uninstall instructions to README

## Test plan

- [ ] Run `sh install.sh` on a clean machine/container to verify source build path
- [ ] Verify shell integration is appended to rc file (idempotent — run twice)
- [ ] Verify `~/.local/bin/` PATH handling when not already on PATH
- [ ] Review README renders correctly on GitHub
