### PR TITLE
chore: bump version to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gx",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "module": "src/index.ts",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary
- Bump package version from `0.1.0` to `0.2.0`

## Test plan
- [x] `bun test` — 147 tests pass
- [x] `gx --version` outputs `gx v0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)