### PR TITLE
docs: add acknowledgements section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ Remove the `# gx` block from your shell config file (`~/.zshrc`, `~/.bashrc`, or
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
+## Acknowledgements
+
+gx draws inspiration from these projects:
+
+- **[ghq](https://github.com/x-motemen/ghq)** — the original structured repository manager. ghq pioneered the `host/owner/repo` directory layout and index-based project lookup that gx builds on.
+- **[gclone](https://github.com/allonsy/gclone)** — a git clone helper with automatic directory organisation, shorthand URL parsing, and shell auto-cd. gx's clone workflow and shell integration owe a lot to gclone's approach.
+
 ## License
 
 MIT

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -119,3 +119,4 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - **D-005:** Dashboard uses local git state only — no remote fetch on `gx dash` (too slow for multi-project scan) — *proposed*
 - **D-006:** `lastVisited` is an optional field on IndexEntry — backward compatible, no migration needed — *proposed*
 - **D-007:** v3 before v4 — tracking and dashboard provide immediate value and inform TUI design — *proposed*
+- **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — *accepted*


### PR DESCRIPTION
## Summary
- Adds an Acknowledgements section to the README crediting ghq and gclone as inspiration for gx's design
- Records decision D-008 in the APS plan index

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Links to ghq and gclone repos are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)