### PR TITLE
fix: hint users to set up shell integration for cd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ curl -fsSL https://raw.githubusercontent.com/joshuaboys/gx/main/install.sh | sh
 
 This downloads (or builds) the `gx` binary, puts it on your PATH, and sets up shell integration with tab completion. Supports zsh, bash, and fish.
 
-> **Note:** Shell integration is required for `gx` to `cd` into projects. The curl installer sets this up automatically. If you installed manually, add `eval "$(gx shell-init)"` to your shell config (see below).
+> **Note:** Shell integration is required for `gx` to `cd` into projects. The curl installer sets this up automatically. If you installed manually, add `eval "$(gx shell-init)"` for bash/zsh or `gx shell-init | source` for fish to your shell config (see below).
 
 <details>
 <summary>Manual install</summary>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ curl -fsSL https://raw.githubusercontent.com/joshuaboys/gx/main/install.sh | sh
 
 This downloads (or builds) the `gx` binary, puts it on your PATH, and sets up shell integration with tab completion. Supports zsh, bash, and fish.
 
+> **Note:** Shell integration is required for `gx` to `cd` into projects. The curl installer sets this up automatically. If you installed manually, add `eval "$(gx shell-init)"` to your shell config (see below).
+
 <details>
 <summary>Manual install</summary>
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,13 @@ Remove the `# gx` block from your shell config file (`~/.zshrc`, `~/.bashrc`, or
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
+## Acknowledgements
+
+gx draws inspiration from these projects:
+
+- **[ghq](https://github.com/x-motemen/ghq)** — the original structured repository manager. ghq pioneered the `host/owner/repo` directory layout and index-based project lookup that gx builds on.
+- **[gclone](https://github.com/allonsy/gclone)** — a git clone helper with automatic directory organisation, shorthand URL parsing, and shell auto-cd. gx's clone workflow and shell integration owe a lot to gclone's approach.
+
 ## License
 
 MIT

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -119,3 +119,4 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - **D-005:** Dashboard uses local git state only — no remote fetch on `gx dash` (too slow for multi-project scan) — *proposed*
 - **D-006:** `lastVisited` is an optional field on IndexEntry — backward compatible, no migration needed — *proposed*
 - **D-007:** v3 before v4 — tracking and dashboard provide immediate value and inform TUI design — *proposed*
+- **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — *accepted*

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ Options:
       await resolve(command, indexPath, config);
       if (process.stdout.isTTY) {
         console.error(
-          `Hint: add shell integration for cd support: eval "$(gx shell-init)"`,
+          `Hint: add shell integration for cd support: run 'gx shell-init' and follow the printed instructions for your shell.`,
         );
       }
       break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,11 @@ Options:
     default:
       // Default: treat as project name to resolve
       await resolve(command, indexPath, config);
+      if (process.stdout.isTTY) {
+        console.error(
+          `Hint: add shell integration for cd support: eval "$(gx shell-init)"`,
+        );
+      }
       break;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a runtime hint to stderr when `gx <project>` is run without shell integration (binary called directly, stdout is a TTY)
- Adds a visible note in the README about the shell integration requirement, outside the collapsed manual install section

## Context
Without shell integration, `gx <project>` prints the path but doesn't cd. This was confusing since the expected behaviour (cd into project) requires the shell wrapper from `gx shell-init`.

## Test plan
- [x] `bun test` — 147 tests pass
- [x] Hint only shows when stdout is a TTY (not when piped/captured by shell wrapper)
- [x] README note renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)