### PR TITLE
feat(aps): scaffold project .apsrc.yaml during init

### DIFF
--- a/lib/scaffold.sh
+++ b/lib/scaffold.sh
@@ -105,7 +105,7 @@ ask_choice() {
   if [[ -t 0 ]]; then
     local hint
     hint="$(IFS='/'; echo "${options[*]}")"
-    printf "%s [%s] (default: %s) " "$prompt" "$hint" "$default"
+    printf "%s [%s] (default: %s) " "$prompt" "$hint" "$default" >&2
     read -r answer
     answer="${answer:-$default}"
 
@@ -333,7 +333,8 @@ cmd_init() {
   install_commands "$target"
   info ".claude/commands/ (plan, plan-status)"
 
-  # Project APS policy config
+  # Project APS policy config (bash scaffold path)
+  # NOTE: PowerShell scaffold parity is tracked separately.
   write_apsrc_config "$target"
 
   echo ""
@@ -444,7 +445,13 @@ cmd_update() {
 
   # Config (optional on update for existing projects)
   if [[ ! -f "$target/.apsrc.yaml" ]]; then
-    if ask_yn "No .apsrc.yaml found. Generate project APS policy now?" "y"; then
+    # Avoid side effects in non-interactive contexts (CI/automation)
+    local apsrc_default="y"
+    if [[ ! -t 0 ]]; then
+      apsrc_default="n"
+    fi
+
+    if ask_yn "No .apsrc.yaml found. Generate project APS policy now?" "$apsrc_default"; then
       write_apsrc_config "$target"
     else
       info "Skipped .apsrc.yaml generation (you can add it later)."

--- a/plans/execution/APSCFG.steps.md
+++ b/plans/execution/APSCFG.steps.md
@@ -1,0 +1,16 @@
+# APSCFG Execution Steps
+
+## APSCFG-001 — Scaffold `.apsrc.yaml` during `aps init`
+
+1. Add a scaffold helper that writes `.apsrc.yaml` with schema `version: 1` defaults.
+2. Call helper from `cmd_init` after APS files are installed.
+3. Ensure helper is no-op if `.apsrc.yaml` already exists.
+4. Update init output tree to include `.apsrc.yaml`.
+5. Run `./bin/aps --help` and a dry init to verify no regression.
+
+## APSCFG-002 — Init-time preference capture
+
+1. Add minimal interactive prompts for verification strictness and gate enforcement.
+2. Persist selected values into `.apsrc.yaml`.
+3. Keep non-interactive mode deterministic via safe defaults.
+4. Verify generated config for both interactive and non-interactive paths.

--- a/plans/execution/APSCFG.steps.md
+++ b/plans/execution/APSCFG.steps.md
@@ -10,7 +10,7 @@
 
 ## APSCFG-002 — Init-time preference capture
 
-1. Add minimal interactive prompts for verification strictness and gate enforcement.
-2. Persist selected values into `.apsrc.yaml`.
+1. Add minimal interactive prompts for profile, verification strictness, and fallback adapters.
+2. Persist selected preference values into `.apsrc.yaml`.
 3. Keep non-interactive mode deterministic via safe defaults.
 4. Verify generated config for both interactive and non-interactive paths.

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -78,6 +78,7 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 | [Distribution & Install UX](./modules/15-distribution.aps.md) | Release binaries, installer, and doctor flow for easy adoption | Draft | v5 | CLI |
 | [Shell Portability](./modules/16-shell-portability.aps.md) | Bash/fish integration and completion parity | Draft | v5 | Shell Plugin, CLI |
 | [Index Reliability & Observability](./modules/17-index-observability.aps.md) | Index diagnostics, stats, and scan telemetry | Draft | v5 | Index, Tracking |
+| [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready | v6 | CLI, APS scaffolding |
 
 ## Risks
 

--- a/plans/modules/18-aps-runtime-provisioning.aps.md
+++ b/plans/modules/18-aps-runtime-provisioning.aps.md
@@ -1,0 +1,67 @@
+# APS Runtime Provisioning & Project Config
+
+| ID | Owner | Status |
+|----|-------|--------|
+| APSCFG | @joshuaboys | Ready |
+
+## Purpose
+Introduce a global-runtime / per-project provisioning model so APS behavior is configured by project policy instead of hardcoded defaults.
+
+## In Scope
+
+- Per-project APS config file (`.apsrc.yaml`)
+- `aps init` preference prompts with persisted toggles
+- Backward-compatible defaults when config is missing
+- Config-aware lint/runtime hooks in subsequent slices
+
+## Out of Scope *(optional)*
+
+- Full remote profile registry
+- Multi-file config inheritance
+- Breaking schema changes without migration support
+
+## Interfaces *(optional)*
+
+**Depends on:**
+
+- APS CLI scaffold/update flow
+- Lint/runtime rule loading
+
+**Exposes:**
+
+- Stable config schema (`version: 1`)
+- Project-level toggles for planning/execution/verification gates
+
+## Ready Checklist
+
+Change status to **Ready** when:
+
+- [x] Purpose and scope are clear
+- [x] Dependencies identified
+- [x] At least one task defined
+
+## Work Items
+
+### APSCFG-001: Scaffold `.apsrc.yaml` during `aps init`
+- **Intent:** Persist project APS policy at bootstrap instead of relying on implicit defaults.
+- **Expected Outcome:** `aps init` writes `.apsrc.yaml` with default keys and values.
+- **Validation:** `./bin/aps init /tmp/aps-init-test && test -f /tmp/aps-init-test/.apsrc.yaml`
+
+### APSCFG-002: Add init-time preference capture
+- **Intent:** Let project owners select key behavior toggles during init.
+- **Expected Outcome:** Interactive `aps init` asks a minimal set of config questions and persists answers.
+- **Validation:** `script -q /tmp/aps-init-capture.log ./bin/aps init /tmp/aps-init-interactive`
+
+### APSCFG-003: Config-aware runtime loading (non-breaking)
+- **Intent:** Ensure runtime can read `.apsrc.yaml` and falls back safely when absent.
+- **Expected Outcome:** CLI loads config when present and behaves identically to current defaults when not.
+- **Validation:** `./bin/aps lint . && rm -f .apsrc.yaml && ./bin/aps lint .`
+
+### APSCFG-004: Migrations & diagnostics
+- **Intent:** Make schema changes safe and observable.
+- **Expected Outcome:** Add migration/doctor workflow contract for future schema bumps.
+- **Validation:** `./bin/aps --help` includes migration/doctor path (or documented placeholder) and docs reference migration flow.
+
+## Execution *(optional)*
+
+Steps: [../execution/APSCFG.steps.md](../execution/APSCFG.steps.md)

--- a/plans/modules/18-aps-runtime-provisioning.aps.md
+++ b/plans/modules/18-aps-runtime-provisioning.aps.md
@@ -62,6 +62,11 @@ Change status to **Ready** when:
 - **Expected Outcome:** Add migration/doctor workflow contract for future schema bumps.
 - **Validation:** `./bin/aps --help` includes migration/doctor path (or documented placeholder) and docs reference migration flow.
 
+### APSCFG-005: Future option — lint gateway enforcement (deferred)
+- **Intent:** Keep strict planning-rule enforcement as an explicit future option without blocking current rollout.
+- **Expected Outcome:** Planning docs record lint-gateway as deferred (`Maybe/Future`) with trigger conditions for adoption.
+- **Validation:** `plans/index.aps.md` or module notes include deferred-item reference.
+
 ## Execution *(optional)*
 
 Steps: [../execution/APSCFG.steps.md](../execution/APSCFG.steps.md)

--- a/plans/modules/18-aps-runtime-provisioning.aps.md
+++ b/plans/modules/18-aps-runtime-provisioning.aps.md
@@ -40,7 +40,7 @@ Change status to **Ready** when:
 - [x] Dependencies identified
 - [x] At least one task defined
 
-## Work Items
+## Tasks
 
 ### APSCFG-001: Scaffold `.apsrc.yaml` during `aps init`
 - **Intent:** Persist project APS policy at bootstrap instead of relying on implicit defaults.


### PR DESCRIPTION
## Summary
- add project APS policy file generation (`.apsrc.yaml`) during `aps init`
- add minimal init-time preference capture (profile, verification strictness, fallback adapters)
- optionally offer `.apsrc.yaml` generation in `aps update` when missing
- add APS planning module + execution steps for runtime provisioning
- record deferred lint-gateway enforcement as future item

## Why
Codifies APS behavior per project while keeping runtime globally installable and repo policy local.

## Validation
- `bash -n lib/scaffold.sh`
- `./bin/aps --help`
- `./bin/aps init <tmpdir>` generates `.apsrc.yaml`
