### PR TITLE
feat(aps): load project config at runtime with defaults

### DIFF
--- a/bin/aps
+++ b/bin/aps
@@ -24,6 +24,7 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 
 # Source library files
 source "$LIB_DIR/output.sh"
+source "$LIB_DIR/config.sh"
 source "$LIB_DIR/rules/common.sh"
 source "$LIB_DIR/rules/module.sh"
 source "$LIB_DIR/rules/index.sh"
@@ -41,6 +42,7 @@ Usage:
   aps update [dir]      Update templates, skill, and commands
   aps lint [file|dir]   Validate APS documents
   aps lint --json       Output results as JSON
+  aps config            Show effective APS runtime config (.apsrc.yaml + defaults)
   aps --help            Show this help
 
 Options:
@@ -56,11 +58,15 @@ Examples:
   aps lint                    # Lint plans/ directory
   aps lint plans/index.aps.md # Lint specific file
   aps lint . --json           # Lint current dir, JSON output
+  aps config                  # Show effective config (file or defaults)
 EOF
 }
 
 main() {
   local cmd="${1:-}"
+
+  # Load project config once (non-breaking defaults if file is absent)
+  load_aps_config "."
 
   case "$cmd" in
     init)
@@ -74,6 +80,9 @@ main() {
     lint)
       shift
       cmd_lint "$@"
+      ;;
+    config)
+      show_aps_config
       ;;
     --help|-h|help|"")
       show_help

--- a/lib/Scaffold.psm1
+++ b/lib/Scaffold.psm1
@@ -41,6 +41,7 @@ $script:CommandFiles = @(
 $script:CliFilesBash = @(
     "bin/aps"
     "lib/output.sh"
+    "lib/config.sh"
     "lib/lint.sh"
     "lib/scaffold.sh"
     "lib/rules/common.sh"

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# APS runtime config loader (.apsrc.yaml)
+#
+
+# Effective runtime defaults (safe, backward-compatible)
+APS_CFG_VERSION="1"
+APS_CFG_MODE_PLANNING="native"
+APS_CFG_MODE_EXECUTION="gated"
+APS_CFG_MODE_VERIFICATION="strict"
+APS_CFG_ADAPTERS_ENABLE_FALLBACK="true"
+APS_CFG_ADAPTERS_REQUIRE_NORMALIZATION="true"
+APS_CFG_GATES_REQUIRE_DESIGN_DRILL="true"
+APS_CFG_GATES_REQUIRE_PROOF_PROGRESS="true"
+APS_CFG_GATES_REQUIRE_DOD_DONE="true"
+APS_CFG_GATES_BLOCKER_ESCALATION_MINUTES="5"
+APS_CFG_PROFILE="startup-ceo"
+APS_CFG_SOURCE="defaults"
+
+# Parse a simple YAML key by exact indentation context and key name.
+# Example: yaml_get "$file" "mode" "verification"
+yaml_get() {
+  local file="$1"
+  local section="$2"
+  local key="$3"
+
+  awk -v section="$section" -v key="$key" '
+    BEGIN { in_section=0 }
+    $0 ~ "^" section ":" { in_section=1; next }
+    in_section && $0 ~ "^[A-Za-z0-9_-]+:" { in_section=0 }
+    in_section {
+      pattern="^[[:space:]]+" key ":[[:space:]]*"
+      if ($0 ~ pattern) {
+        sub(pattern, "", $0)
+        gsub(/[[:space:]]+#.*/, "", $0)
+        gsub(/^"|"$/, "", $0)
+        gsub(/^\047|\047$/, "", $0)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+        print $0
+        exit
+      }
+    }
+  ' "$file"
+}
+
+load_aps_config() {
+  local root="${1:-.}"
+  local file="$root/.apsrc.yaml"
+
+  # reset to defaults on each load
+  APS_CFG_VERSION="1"
+  APS_CFG_MODE_PLANNING="native"
+  APS_CFG_MODE_EXECUTION="gated"
+  APS_CFG_MODE_VERIFICATION="strict"
+  APS_CFG_ADAPTERS_ENABLE_FALLBACK="true"
+  APS_CFG_ADAPTERS_REQUIRE_NORMALIZATION="true"
+  APS_CFG_GATES_REQUIRE_DESIGN_DRILL="true"
+  APS_CFG_GATES_REQUIRE_PROOF_PROGRESS="true"
+  APS_CFG_GATES_REQUIRE_DOD_DONE="true"
+  APS_CFG_GATES_BLOCKER_ESCALATION_MINUTES="5"
+  APS_CFG_PROFILE="startup-ceo"
+  APS_CFG_SOURCE="defaults"
+
+  if [[ ! -f "$file" ]]; then
+    return 0
+  fi
+
+  local v
+
+  v=$(grep -E '^version:[[:space:]]*' "$file" | head -1 | sed -E 's/^version:[[:space:]]*//' | tr -d '"\047' | xargs || true)
+  [[ -n "$v" ]] && APS_CFG_VERSION="$v"
+
+  v=$(yaml_get "$file" "mode" "planning" || true)
+  [[ -n "$v" ]] && APS_CFG_MODE_PLANNING="$v"
+
+  v=$(yaml_get "$file" "mode" "execution" || true)
+  [[ -n "$v" ]] && APS_CFG_MODE_EXECUTION="$v"
+
+  v=$(yaml_get "$file" "mode" "verification" || true)
+  [[ -n "$v" ]] && APS_CFG_MODE_VERIFICATION="$v"
+
+  v=$(yaml_get "$file" "adapters" "enableFallbackAdapters" || true)
+  [[ -n "$v" ]] && APS_CFG_ADAPTERS_ENABLE_FALLBACK="$v"
+
+  v=$(yaml_get "$file" "adapters" "requireSchemaNormalization" || true)
+  [[ -n "$v" ]] && APS_CFG_ADAPTERS_REQUIRE_NORMALIZATION="$v"
+
+  v=$(yaml_get "$file" "gates" "requireDesignDrill" || true)
+  [[ -n "$v" ]] && APS_CFG_GATES_REQUIRE_DESIGN_DRILL="$v"
+
+  v=$(yaml_get "$file" "gates" "requireProofForProgress" || true)
+  [[ -n "$v" ]] && APS_CFG_GATES_REQUIRE_PROOF_PROGRESS="$v"
+
+  v=$(yaml_get "$file" "gates" "requireDodForDone" || true)
+  [[ -n "$v" ]] && APS_CFG_GATES_REQUIRE_DOD_DONE="$v"
+
+  v=$(yaml_get "$file" "gates" "blockerEscalationMinutes" || true)
+  [[ -n "$v" ]] && APS_CFG_GATES_BLOCKER_ESCALATION_MINUTES="$v"
+
+  v=$(yaml_get "$file" "init" "profile" || true)
+  [[ -n "$v" ]] && APS_CFG_PROFILE="$v"
+
+  APS_CFG_SOURCE="$file"
+}
+
+show_aps_config() {
+  cat <<EOF
+APS config
+source: $APS_CFG_SOURCE
+version: $APS_CFG_VERSION
+mode.planning: $APS_CFG_MODE_PLANNING
+mode.execution: $APS_CFG_MODE_EXECUTION
+mode.verification: $APS_CFG_MODE_VERIFICATION
+adapters.enableFallbackAdapters: $APS_CFG_ADAPTERS_ENABLE_FALLBACK
+adapters.requireSchemaNormalization: $APS_CFG_ADAPTERS_REQUIRE_NORMALIZATION
+gates.requireDesignDrill: $APS_CFG_GATES_REQUIRE_DESIGN_DRILL
+gates.requireProofForProgress: $APS_CFG_GATES_REQUIRE_PROOF_PROGRESS
+gates.requireDodForDone: $APS_CFG_GATES_REQUIRE_DOD_DONE
+gates.blockerEscalationMinutes: $APS_CFG_GATES_BLOCKER_ESCALATION_MINUTES
+init.profile: $APS_CFG_PROFILE
+EOF
+}

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -3,19 +3,24 @@
 # APS runtime config loader (.apsrc.yaml)
 #
 
-# Effective runtime defaults (safe, backward-compatible)
-APS_CFG_VERSION="1"
-APS_CFG_MODE_PLANNING="native"
-APS_CFG_MODE_EXECUTION="gated"
-APS_CFG_MODE_VERIFICATION="strict"
-APS_CFG_ADAPTERS_ENABLE_FALLBACK="true"
-APS_CFG_ADAPTERS_REQUIRE_NORMALIZATION="true"
-APS_CFG_GATES_REQUIRE_DESIGN_DRILL="true"
-APS_CFG_GATES_REQUIRE_PROOF_PROGRESS="true"
-APS_CFG_GATES_REQUIRE_DOD_DONE="true"
-APS_CFG_GATES_BLOCKER_ESCALATION_MINUTES="5"
-APS_CFG_PROFILE="startup-ceo"
-APS_CFG_SOURCE="defaults"
+aps_config_reset_defaults() {
+  # Effective runtime defaults (safe, backward-compatible)
+  APS_CFG_VERSION="1"
+  APS_CFG_MODE_PLANNING="native"
+  APS_CFG_MODE_EXECUTION="gated"
+  APS_CFG_MODE_VERIFICATION="strict"
+  APS_CFG_ADAPTERS_ENABLE_FALLBACK="true"
+  APS_CFG_ADAPTERS_REQUIRE_NORMALIZATION="true"
+  APS_CFG_GATES_REQUIRE_DESIGN_DRILL="true"
+  APS_CFG_GATES_REQUIRE_PROOF_PROGRESS="true"
+  APS_CFG_GATES_REQUIRE_DOD_DONE="true"
+  APS_CFG_GATES_BLOCKER_ESCALATION_MINUTES="5"
+  APS_CFG_PROFILE="startup-ceo"
+  APS_CFG_SOURCE="defaults"
+}
+
+# Initialize defaults at file load
+aps_config_reset_defaults
 
 # Parse a simple YAML key by exact indentation context and key name.
 # Example: yaml_get "$file" "mode" "verification"
@@ -32,7 +37,11 @@ yaml_get() {
       pattern="^[[:space:]]+" key ":[[:space:]]*"
       if ($0 ~ pattern) {
         sub(pattern, "", $0)
-        gsub(/[[:space:]]+#.*/, "", $0)
+        if ($0 ~ /^[[:space:]]*#/) {
+          $0 = ""
+        } else {
+          gsub(/[[:space:]]+#.*/, "", $0)
+        }
         gsub(/^"|"$/, "", $0)
         gsub(/^\047|\047$/, "", $0)
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
@@ -48,26 +57,20 @@ load_aps_config() {
   local file="$root/.apsrc.yaml"
 
   # reset to defaults on each load
-  APS_CFG_VERSION="1"
-  APS_CFG_MODE_PLANNING="native"
-  APS_CFG_MODE_EXECUTION="gated"
-  APS_CFG_MODE_VERIFICATION="strict"
-  APS_CFG_ADAPTERS_ENABLE_FALLBACK="true"
-  APS_CFG_ADAPTERS_REQUIRE_NORMALIZATION="true"
-  APS_CFG_GATES_REQUIRE_DESIGN_DRILL="true"
-  APS_CFG_GATES_REQUIRE_PROOF_PROGRESS="true"
-  APS_CFG_GATES_REQUIRE_DOD_DONE="true"
-  APS_CFG_GATES_BLOCKER_ESCALATION_MINUTES="5"
-  APS_CFG_PROFILE="startup-ceo"
-  APS_CFG_SOURCE="defaults"
+  aps_config_reset_defaults
 
   if [[ ! -f "$file" ]]; then
     return 0
   fi
 
+  if [[ ! -r "$file" ]]; then
+    echo "warning: APS config file '$file' exists but is not readable; using defaults" >&2
+    return 0
+  fi
+
   local v
 
-  v=$(grep -E '^version:[[:space:]]*' "$file" | head -1 | sed -E 's/^version:[[:space:]]*//' | tr -d '"\047' | xargs || true)
+  v=$(grep -E '^version:[[:space:]]*' "$file" | head -1 | sed -E 's/^version:[[:space:]]*//' | sed -E 's/[[:space:]]+#.*$//' | tr -d '"\047' | xargs || true)
   [[ -n "$v" ]] && APS_CFG_VERSION="$v"
 
   v=$(yaml_get "$file" "mode" "planning" || true)

--- a/lib/scaffold.sh
+++ b/lib/scaffold.sh
@@ -47,6 +47,7 @@ CLI_FILES=(
   "bin/aps.ps1"
   "lib/output.sh"
   "lib/Output.psm1"
+  "lib/config.sh"
   "lib/lint.sh"
   "lib/Lint.psm1"
   "lib/scaffold.sh"


### PR DESCRIPTION
## Summary
- add `lib/config.sh` to load effective APS runtime config from `.apsrc.yaml`
- keep strict backward-compatible defaults when config file is absent
- wire runtime loading into `bin/aps` startup path
- add `aps config` command to show effective runtime values/source
- include `lib/config.sh` in scaffolded CLI file set

## Why
Completes Piece A: runtime config loading so APS behavior can be project-scoped without breaking existing repos.

## Validation
- `bash -n bin/aps lib/config.sh lib/scaffold.sh`
- `./bin/aps --help`
- `./bin/aps config` (defaults path)
- `./bin/aps config` from dir containing `.apsrc.yaml` (file overrides)
