### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/joshuaboys/gx/security/code-scanning/2](https://github.com/joshuaboys/gx/security/code-scanning/2)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in this workflow to the least privileges required. This job only checks out code and runs Bun commands (install, type check, test, build), which only require read access to the repository contents. Therefore, adding `permissions: contents: read` is sufficient.

The cleanest minimal change is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`). This will apply to all jobs that don’t override it. Specifically, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block. No imports or additional methods are needed, since this is purely a YAML configuration change for GitHub Actions and does not affect existing functionality of the job steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
