### PR TITLE
docs: restructure README with hero section, features, and quick start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,30 +35,7 @@ bun test
 
 ## Project structure
 
-```
-src/
-  index.ts              # CLI entry point and command router
-  commands/
-    clone.ts            # gx clone
-    config.ts           # gx config
-    init.ts             # gx init (.claude/ scaffolding)
-    ls.ts               # gx ls
-    open.ts             # gx open
-    rebuild.ts          # gx rebuild
-    resolve.ts          # gx <name> (project lookup)
-    shell-init.ts       # gx shell-init (shell integration generator)
-  lib/
-    config.ts           # Config file management (~/.config/gx/config.json)
-    detect.ts           # Project type detection
-    fuzzy.ts            # Fuzzy matching for project names
-    index.ts            # ProjectIndex class (project registry, rebuild, save/load)
-    path.ts             # Path resolution and project indexing
-    templates.ts        # .claude/ scaffolding templates
-    url.ts              # Git URL parsing
-plugin/
-  gx.plugin.zsh        # oh-my-zsh compatibility shim
-install.sh              # Curl installer
-```
+See [AGENTS.md](AGENTS.md) for the full project structure and file descriptions.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,54 @@
+<div align="center">
+
 # gx
+
+**A fast git project manager — clone, jump, and organize repos from the terminal.**
 
 [![CI](https://github.com/joshuaboys/gx/actions/workflows/ci.yml/badge.svg)](https://github.com/joshuaboys/gx/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Built with Bun](https://img.shields.io/badge/Built%20with-Bun-f9f1e1?logo=bun)](https://bun.sh)
 
-A fast git project manager for cloning, navigating, and organising repositories.
+</div>
+
+---
+
+## Features
+
+- **Instant project switching** — jump to any repo by name with fuzzy matching
+- **Structured organization** — repos are cloned into a consistent `owner/repo` layout
+- **GitHub shorthand** — `gx clone user/repo` just works
+- **Shell integration** — tab completion and auto-`cd` for zsh, bash, and fish
+- **Open in any editor** — `gx open` launches VS Code, nvim, or whatever you use
+- **AI agent scaffolding** — `gx init` generates `.claude/` configs tailored to your project's language
+- **Single binary** — zero runtime dependencies, compiles with Bun
+
+## Quick Start
+
+```sh
+# Install
+curl -fsSL https://raw.githubusercontent.com/joshuaboys/gx/main/install.sh | sh
+
+# Clone a repo and cd into it
+gx clone user/repo
+
+# Jump back to it later
+gx repo
+```
+
+That's it. Shell integration and tab completion are set up automatically.
 
 ## Install
+
+The curl installer downloads (or builds) the `gx` binary, puts it on your `PATH`, and sets up shell integration with tab completion.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/joshuaboys/gx/main/install.sh | sh
 ```
 
-This downloads (or builds) the `gx` binary, puts it on your PATH, and sets up shell integration with tab completion. Supports zsh, bash, and fish.
-
-> **Note:** Shell integration is required for `gx` to `cd` into projects. The curl installer sets this up automatically. If you installed manually, add `eval "$(gx shell-init)"` for bash/zsh or `gx shell-init | source` for fish to your shell config (see below).
+> **Note:** Shell integration is required for `gx` to `cd` into projects. The installer sets this up automatically. If you installed manually, add `eval "$(gx shell-init)"` for bash/zsh or `gx shell-init | source` for fish to your shell config.
 
 <details>
-<summary>Manual install</summary>
+<summary><strong>Manual install</strong></summary>
 
 Requires [Bun](https://bun.sh) v1.0+.
 
@@ -39,10 +70,11 @@ eval "$(gx shell-init)"
 ```fish
 gx shell-init | source
 ```
+
 </details>
 
 <details>
-<summary>oh-my-zsh (legacy)</summary>
+<summary><strong>oh-my-zsh (legacy)</strong></summary>
 
 If you already use gx as an oh-my-zsh plugin, it still works:
 
@@ -52,19 +84,10 @@ ln -s /path/to/gx/plugin ~/.oh-my-zsh/custom/plugins/gx
 ```
 
 The plugin file now delegates to `gx shell-init` internally.
+
 </details>
 
 ## Usage
-
-### Clone a repository
-
-```sh
-gx clone user/repo              # GitHub shorthand
-gx clone https://github.com/user/repo
-gx clone git@github.com:user/repo.git
-```
-
-Repositories are cloned to `~/Projects/src/<owner>/<repo>` by default and the shell cd's into the new directory.
 
 ### Jump to a project
 
@@ -74,6 +97,16 @@ gx myproj           # fuzzy match fallback
 ```
 
 Tab completion works for all indexed project names.
+
+### Clone a repository
+
+```sh
+gx clone user/repo              # GitHub shorthand
+gx clone https://github.com/user/repo
+gx clone git@github.com:user/repo.git
+```
+
+Repositories are cloned to `~/Projects/src/<owner>/<repo>` by default and the shell `cd`s into the new directory.
 
 ### List projects
 
@@ -101,45 +134,6 @@ gx init --force            # overwrite existing .claude/
 
 Creates `.claude/CLAUDE.md` and `.claude/commands/` with plan and review slash commands. Supports project types: `typescript-bun`, `typescript-node`, `rust`, `go`, `python`, `generic`.
 
-## Configuration
-
-```sh
-gx config                         # show current config
-gx config set projectDir ~/code   # change project directory
-gx config set structure flat      # use repo-only layout
-gx config set structure owner    # use owner/repo layout (default)
-gx config set structure host     # use host/owner/repo layout
-gx config set editor code         # set default editor
-```
-
-Config is stored at `~/.config/gx/config.json`.
-
-### Directory structure
-
-By default, gx uses the `owner` structure:
-
-```
-~/Projects/src/
-  owner/repo/
-  owner/other-repo/
-```
-
-Set `structure` to `flat` for a repo-only layout (no owner prefix):
-
-```
-~/Projects/src/
-  repo/
-  other-repo/
-```
-
-Set `structure` to `host` for host-prefixed layout:
-
-```
-~/Projects/src/
-  github.com/owner/repo/
-  gitlab.com/owner/other-repo/
-```
-
 ### Rebuild index
 
 ```sh
@@ -147,6 +141,54 @@ gx rebuild
 ```
 
 Rescans the project directory and rebuilds the project index.
+
+## Configuration
+
+```sh
+gx config                         # show current config
+gx config set projectDir ~/code   # change project directory
+gx config set structure flat      # use repo-only layout
+gx config set structure owner     # use owner/repo layout (default)
+gx config set structure host      # use host/owner/repo layout
+gx config set editor code         # set default editor
+```
+
+Config is stored at `~/.config/gx/config.json`.
+
+### Directory structures
+
+<table>
+<tr><th><code>owner</code> (default)</th><th><code>flat</code></th><th><code>host</code></th></tr>
+<tr>
+<td>
+
+```
+~/Projects/src/
+  owner/repo/
+  owner/other-repo/
+```
+
+</td>
+<td>
+
+```
+~/Projects/src/
+  repo/
+  other-repo/
+```
+
+</td>
+<td>
+
+```
+~/Projects/src/
+  github.com/owner/repo/
+  gitlab.com/owner/other-repo/
+```
+
+</td>
+</tr>
+</table>
 
 ## Uninstall
 
@@ -156,9 +198,10 @@ rm ~/.local/bin/gx
 
 Remove the `# gx` block from your shell config file (`~/.zshrc`, `~/.bashrc`, or `~/.config/fish/conf.d/gx.fish`).
 
-## Contributing
+## More
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+- [Use cases & examples](docs/use-cases.md) — real-world workflows, scripting recipes, and shell aliases
+- [Contributing](CONTRIBUTING.md) — development setup and guidelines
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@
 ```sh
 # Install
 curl -fsSL https://raw.githubusercontent.com/joshuaboys/gx/main/install.sh | sh
+exec $SHELL   # reload to pick up PATH and shell integration
 
 # Clone a repo and cd into it
 gx clone user/repo
 
 # Jump back to it later
-gx repo
+gx myproject
 ```
 
 That's it. Shell integration and tab completion are set up automatically.
@@ -62,11 +63,13 @@ cp gx ~/.local/bin/
 Add shell integration to your config file:
 
 **zsh** (`~/.zshrc`) / **bash** (`~/.bashrc`):
+
 ```sh
 eval "$(gx shell-init)"
 ```
 
 **fish** (`~/.config/fish/conf.d/gx.fish`):
+
 ```fish
 gx shell-init | source
 ```

--- a/aps-planning/examples.md
+++ b/aps-planning/examples.md
@@ -2,10 +2,8 @@
 
 Real-world examples of APS specs at different scales.
 
-> **Canonical examples:** For full worked examples with complete file trees, see
-> [examples/user-auth/](../examples/user-auth/) and
-> [examples/opencode-companion/](../examples/opencode-companion/). The examples
-> below are compact summaries for quick context-window access.
+> The examples below are compact summaries for quick reference. Each demonstrates
+> the APS format at a different scale.
 
 ## Example 1: Quick Feature (Simple Spec)
 

--- a/docs/plans/2026-02-22-gx-design.md
+++ b/docs/plans/2026-02-22-gx-design.md
@@ -1,4 +1,6 @@
-# gx Design Document
+# gx Design Document (v1)
+
+> **Note:** This document covers the v1 architecture. For v2 features (editor integration, AI scaffolding, shell portability) and planned v3/v4 work, see [v3v4-roadmap.md](2026-02-23-gx-v3v4-roadmap.md).
 
 ## Overview
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -2,6 +2,21 @@
 
 Real-world workflows where gx streamlines day-to-day development.
 
+## Contents
+
+- [Rapid Context Switching](#1-rapid-context-switching)
+- [Scripting with the Index](#2-scripting-with-the-index)
+- [Onboarding onto a New Machine](#3-onboarding-onto-a-new-machine)
+- [Polyglot Multi-Repo Development](#4-polyglot-multi-repo-development)
+- [Scaffolding AI Agent Configs](#5-scaffolding-ai-agent-configs-across-projects)
+- [Quick Code Review](#6-quick-code-review-across-repos)
+- [CI/CD & Automation Scripts](#7-cicd--automation-scripts)
+- [Workspace Auditing](#8-workspace-auditing)
+- [Feeding Context to LLMs](#9-feeding-context-to-llms--ai-tools)
+- [Team Standardisation](#10-team-standardisation)
+- [Shell Aliases & Integrations](#11-shell-aliases--integrations)
+- [Monorepo-Adjacent Workflows](#12-monorepo-adjacent-workflows)
+
 ---
 
 ## 1. Rapid Context Switching

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -12,7 +12,7 @@ Real-world workflows where gx streamlines day-to-day development.
 - [Quick Code Review](#6-quick-code-review-across-repos)
 - [CI/CD & Automation Scripts](#7-cicd--automation-scripts)
 - [Workspace Auditing](#8-workspace-auditing)
-- [Feeding Context to LLMs](#9-feeding-context-to-llms--ai-tools)
+- [Feeding Context to LLMs & AI Tools](#9-feeding-context-to-llms--ai-tools)
 - [Team Standardisation](#10-team-standardisation)
 - [Shell Aliases & Integrations](#11-shell-aliases--integrations)
 - [Monorepo-Adjacent Workflows](#12-monorepo-adjacent-workflows)
@@ -300,17 +300,17 @@ code "$(gx resolve shared-lib)" "$(gx resolve api-server)" "$(gx resolve dashboa
 
 ## Summary
 
-| Use Case | Key Commands |
-|----------|-------------|
-| Context switching | `gx <name>` |
-| Scripting with index | `gx resolve`, `gx resolve --list` |
-| Machine onboarding | `gx clone`, `gx ls` |
-| Multi-language navigation | `gx <name>` with fuzzy matching |
-| AI agent scaffolding | `gx init` |
-| Code review | `gx open --editor` |
-| CI/CD path lookup | `gx resolve <name>` |
-| Workspace auditing | `gx resolve --list` + git commands |
-| LLM context generation | Index JSON + `gx resolve --list` |
-| Team standardisation | `gx config set` |
-| Custom shell aliases | Shell functions wrapping gx |
-| Multi-repo coordination | `gx resolve` in loops |
+| Use Case                  | Key Commands                       |
+| ------------------------- | ---------------------------------- |
+| Context switching         | `gx <name>`                        |
+| Scripting with index      | `gx resolve`, `gx resolve --list`  |
+| Machine onboarding        | `gx clone`, `gx ls`                |
+| Multi-language navigation | `gx <name>` with fuzzy matching    |
+| AI agent scaffolding      | `gx init`                          |
+| Code review               | `gx open --editor`                 |
+| CI/CD path lookup         | `gx resolve <name>`                |
+| Workspace auditing        | `gx resolve --list` + git commands |
+| LLM context generation    | Index JSON + `gx resolve --list`   |
+| Team standardisation      | `gx config set`                    |
+| Custom shell aliases      | Shell functions wrapping gx        |
+| Multi-repo coordination   | `gx resolve` in loops              |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "gx",
+  "description": "A fast git project manager for cloning, navigating, and organizing repositories",
   "version": "0.2.0",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Restructure README with centered hero, feature highlights, and quick start section (patterns from fzf, zoxide, starship)
- Reorder usage to lead with "Jump to a project" (the hero feature, not clone)
- Directory structures shown side-by-side in an HTML table
- Add table of contents to use-cases.md for navigation
- Deduplicate project structure in CONTRIBUTING.md (references AGENTS.md)
- Add v1 scope note and v3v4 cross-reference to design.md
- Remove dead directory references in aps-planning/examples.md
- Add description field to package.json

## Test plan
- [ ] Verify README renders correctly on GitHub (centered hero, badges, collapsible sections, HTML table)
- [ ] Confirm all links work (CONTRIBUTING.md, LICENSE, docs/use-cases.md, badge URLs)
- [ ] Verify use-cases.md TOC anchor links resolve correctly
- [ ] No content lost from original README

🤖 Generated with [Claude Code](https://claude.com/claude-code)