### PR TITLE
feat(shell): add worktrunk (wt) integration

### DIFF
--- a/src/commands/shell-init.ts
+++ b/src/commands/shell-init.ts
@@ -82,7 +82,7 @@ gx() {
 # Tab completion
 _gx() {
     local -a commands projects
-    commands=(clone ls rebuild config resolve open init shell-init --help --version)
+    commands=(clone ls rebuild config resolve open init shell-init --help --version -h -v)
 
     if (( CURRENT == 2 )); then
         projects=($("$_GX_BIN" resolve --list 2>/dev/null))
@@ -157,7 +157,7 @@ _gx_completions() {
     local prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
     if [ "\$COMP_CWORD" -eq 1 ]; then
-        local commands="clone ls rebuild config resolve open init shell-init --help --version"
+        local commands="clone ls rebuild config resolve open init shell-init --help --version -h -v"
         local projects
         projects=$("$_GX_BIN" resolve --list 2>/dev/null)
         COMPREPLY=($(compgen -W "$commands $projects" -- "$cur"))
@@ -217,7 +217,7 @@ end
 
 # Tab completion
 complete -c gx -f
-complete -c gx -n "__fish_use_subcommand" -a "clone ls rebuild config resolve open init shell-init --help --version"
+complete -c gx -n "__fish_use_subcommand" -a "clone ls rebuild config resolve open init shell-init --help --version -h -v"
 complete -c gx -n "__fish_use_subcommand" -a "($_GX_BIN resolve --list 2>/dev/null)"
 complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
 complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"

--- a/src/commands/shell-init.ts
+++ b/src/commands/shell-init.ts
@@ -66,6 +66,15 @@ gx() {
             else
                 return 1
             fi
+            if [ "$2" = "wt" ]; then
+                if ! command -v wt >/dev/null 2>&1; then
+                    echo "gx: wt (worktrunk) not found on PATH" >&2
+                    echo "Install: brew install worktrunk" >&2
+                    return 1
+                fi
+                shift 2
+                wt "$@"
+            fi
             ;;
     esac
 }
@@ -78,8 +87,17 @@ _gx() {
     if (( CURRENT == 2 )); then
         projects=($("$_GX_BIN" resolve --list 2>/dev/null))
         compadd "\${commands[@]}" "\${projects[@]}"
-    elif (( CURRENT == 3 )) && [[ "\${words[2]}" == "config" ]]; then
-        compadd set
+    elif (( CURRENT == 3 )); then
+        case "\${words[2]}" in
+            clone|ls|rebuild|config|resolve|open|init|shell-init|--help|--version|-h|-v)
+                if [[ "\${words[2]}" == "config" ]]; then
+                    compadd set
+                fi
+                ;;
+            *)
+                compadd wt
+                ;;
+        esac
     elif (( CURRENT == 4 )) && [[ "\${words[2]}" == "config" ]] && [[ "\${words[3]}" == "set" ]]; then
         compadd projectDir defaultHost structure shallow similarityThreshold editor
     fi
@@ -120,6 +138,15 @@ gx() {
             else
                 return 1
             fi
+            if [ "$2" = "wt" ]; then
+                if ! command -v wt >/dev/null 2>&1; then
+                    echo "gx: wt (worktrunk) not found on PATH" >&2
+                    echo "Install: brew install worktrunk" >&2
+                    return 1
+                fi
+                shift 2
+                wt "$@"
+            fi
             ;;
     esac
 }
@@ -134,8 +161,17 @@ _gx_completions() {
         local projects
         projects=$("$_GX_BIN" resolve --list 2>/dev/null)
         COMPREPLY=($(compgen -W "$commands $projects" -- "$cur"))
-    elif [ "\$COMP_CWORD" -eq 2 ] && [ "$prev" = "config" ]; then
-        COMPREPLY=($(compgen -W "set" -- "$cur"))
+    elif [ "\$COMP_CWORD" -eq 2 ]; then
+        case "\${COMP_WORDS[1]}" in
+            clone|ls|rebuild|config|resolve|open|init|shell-init|--help|--version|-h|-v)
+                if [ "\${COMP_WORDS[1]}" = "config" ]; then
+                    COMPREPLY=($(compgen -W "set" -- "$cur"))
+                fi
+                ;;
+            *)
+                COMPREPLY=($(compgen -W "wt" -- "$cur"))
+                ;;
+        esac
     elif [ "\$COMP_CWORD" -eq 3 ] && [ "\${COMP_WORDS[1]}" = "config" ] && [ "$prev" = "set" ]; then
         COMPREPLY=($(compgen -W "projectDir defaultHost structure shallow similarityThreshold editor" -- "$cur"))
     fi
@@ -168,6 +204,14 @@ function gx
             else
                 return 1
             end
+            if test "$argv[2]" = "wt"
+                if not command -v wt >/dev/null 2>&1
+                    echo "gx: wt (worktrunk) not found on PATH" >&2
+                    echo "Install: brew install worktrunk" >&2
+                    return 1
+                end
+                wt $argv[3..]
+            end
     end
 end
 
@@ -176,7 +220,8 @@ complete -c gx -f
 complete -c gx -n "__fish_use_subcommand" -a "clone ls rebuild config resolve open init shell-init --help --version"
 complete -c gx -n "__fish_use_subcommand" -a "($_GX_BIN resolve --list 2>/dev/null)"
 complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
-complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"`;
+complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"
+complete -c gx -n "not __fish_seen_subcommand_from clone ls rebuild config resolve open init shell-init; and test (count (commandline -opc)) -eq 2" -a "wt"`;
 }
 
 export function shellInit(shellArg?: string): void {
@@ -193,7 +238,9 @@ export function shellInit(shellArg?: string): void {
     shell = detectShell();
     if (!shell) {
       console.error("Could not detect shell from $SHELL");
-      console.error(`Specify one explicitly: gx shell-init <${SUPPORTED_SHELLS.join("|")}>`);
+      console.error(
+        `Specify one explicitly: gx shell-init <${SUPPORTED_SHELLS.join("|")}>`,
+      );
       process.exit(1);
     }
   }

--- a/src/commands/shell-init.ts
+++ b/src/commands/shell-init.ts
@@ -221,7 +221,7 @@ complete -c gx -n "__fish_use_subcommand" -a "clone ls rebuild config resolve op
 complete -c gx -n "__fish_use_subcommand" -a "($_GX_BIN resolve --list 2>/dev/null)"
 complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
 complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"
-complete -c gx -n "not __fish_seen_subcommand_from clone ls rebuild config resolve open init shell-init; and test (count (commandline -opc)) -eq 2" -a "wt"`;
+complete -c gx -n "not __fish_seen_subcommand_from clone ls rebuild config resolve open init shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt"`;
 }
 
 export function shellInit(shellArg?: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ async function main() {
 
 Usage:
   gx <name>                Jump to project
+  gx <name> wt [args...]   Jump to project and run wt (worktrunk)
   gx clone <repo>          Clone and jump to repo
   gx open [name]           Open project in editor
   gx ls                    List indexed projects
@@ -98,9 +99,7 @@ Options:
       }
       const name = args.find(
         (a, i) =>
-          i > 0 &&
-          a !== "--editor" &&
-          (editorFlag < 0 || i !== editorFlag + 1),
+          i > 0 && a !== "--editor" && (editorFlag < 0 || i !== editorFlag + 1),
       );
       await openProject(name, config, indexPath, editor);
       break;

--- a/tests/commands/shell-init.test.ts
+++ b/tests/commands/shell-init.test.ts
@@ -162,6 +162,56 @@ describe("shellInit", () => {
   });
 });
 
+describe("wt (worktrunk) integration", () => {
+  test("zsh includes wt dispatch in default case", () => {
+    const output = captureOutput(() => shellInit("zsh"));
+    expect(output).toContain('"$2" = "wt"');
+    expect(output).toContain("command -v wt");
+    expect(output).toContain("shift 2");
+    expect(output).toContain('wt "$@"');
+  });
+
+  test("bash includes wt dispatch in default case", () => {
+    const output = captureOutput(() => shellInit("bash"));
+    expect(output).toContain('"$2" = "wt"');
+    expect(output).toContain("command -v wt");
+    expect(output).toContain("shift 2");
+    expect(output).toContain('wt "$@"');
+  });
+
+  test("fish includes wt dispatch in default case", () => {
+    const output = captureOutput(() => shellInit("fish"));
+    expect(output).toContain('"$argv[2]" = "wt"');
+    expect(output).toContain("command -v wt");
+    expect(output).toContain("wt $argv[3..]");
+  });
+
+  test("all shells include install hint when wt missing", () => {
+    for (const shell of ["zsh", "bash", "fish"] as const) {
+      const output = captureOutput(() => shellInit(shell));
+      expect(output).toContain("brew install worktrunk");
+    }
+  });
+
+  test("zsh completion offers wt after project name", () => {
+    const output = captureOutput(() => shellInit("zsh"));
+    expect(output).toContain("compadd wt");
+  });
+
+  test("bash completion offers wt after project name", () => {
+    const output = captureOutput(() => shellInit("bash"));
+    expect(output).toContain('compgen -W "wt"');
+  });
+
+  test("fish completion offers wt after project name", () => {
+    const output = captureOutput(() => shellInit("fish"));
+    expect(output).toContain(
+      'complete -c gx -n "not __fish_seen_subcommand_from',
+    );
+    expect(output).toContain('-a "wt"');
+  });
+});
+
 describe("resolveGxBin PATH lookup", () => {
   let whichSpy: ReturnType<typeof spyOn>;
 

--- a/tests/commands/shell-init.test.ts
+++ b/tests/commands/shell-init.test.ts
@@ -186,7 +186,7 @@ describe("wt (worktrunk) integration", () => {
     expect(output).toContain("wt $argv[3..]");
   });
 
-  test("all shells include install hint when wt missing", () => {
+  test("all shells include wt install hint in generated output", () => {
     for (const shell of ["zsh", "bash", "fish"] as const) {
       const output = captureOutput(() => shellInit(shell));
       expect(output).toContain("brew install worktrunk");


### PR DESCRIPTION
## Summary
- Adds `gx <project> wt [args...]` to cd into a project and run worktrunk in one command
- Includes `command -v wt` check with install hint (`brew install worktrunk`) when wt is missing
- Updates tab completion for all three shells (zsh, bash, fish) to offer `wt` after a project name
- Adds 7 new tests covering wt dispatch, install hint, and completion output

## Examples
```sh
gx anvil wt switch -c bug-squash   # cd to anvil, create worktree
gx anvil wt list                    # cd to anvil, list worktrees
gx anvil wt                         # cd to anvil, open wt interactive picker
```

## Test plan
- [x] `bun x tsc --noEmit` passes
- [x] `bun test` — 154/154 tests pass (7 new)
- [x] `bun run build` compiles successfully
- [ ] Manual: `eval "$(./gx shell-init zsh)"` then `gx <project> wt list` (requires worktrunk installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)