### PR TITLE
feat(agent): add GX_AGENT env var for agent-scoped directories

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,17 +1,28 @@
-import { loadConfig, saveConfig } from "../lib/config.ts";
+import {
+  loadConfig,
+  saveConfig,
+  getAgent,
+  effectiveProjectDir,
+} from "../lib/config.ts";
 import type { Config } from "../types.ts";
 
 const VALID_STRUCTURES = new Set(["flat", "owner", "host"]);
 
 export async function showConfig(configPath: string): Promise<void> {
   const config = await loadConfig(configPath);
-  console.log(JSON.stringify(config, null, 2));
+  const agent = getAgent();
+  const output: Record<string, unknown> = { ...config };
+  if (agent) {
+    output.agent = agent;
+    output.effectiveProjectDir = effectiveProjectDir(config);
+  }
+  console.log(JSON.stringify(output, null, 2));
 }
 
 export async function setConfig(
   configPath: string,
   key: string,
-  value: string
+  value: string,
 ): Promise<void> {
   const config = await loadConfig(configPath);
   if (!(key in config)) {

--- a/src/commands/index-repos.ts
+++ b/src/commands/index-repos.ts
@@ -1,7 +1,7 @@
 import { resolve as resolvePath, basename, join } from "path";
 import { lstat } from "fs/promises";
 import { ProjectIndex } from "../lib/index.ts";
-import { expandTilde } from "../lib/config.ts";
+import { expandTilde, effectiveProjectDir } from "../lib/config.ts";
 import type { Config } from "../types.ts";
 
 export async function indexRepos(
@@ -24,11 +24,14 @@ async function indexPaths(paths: string[], indexPath: string): Promise<void> {
     const absPath = resolvePath(expandTilde(rawPath));
 
     // Verify this is a real git worktree
-    const verifyProc = Bun.spawn(["git", "rev-parse", "--is-inside-work-tree"], {
-      cwd: absPath,
-      stdout: "pipe",
-      stderr: "ignore",
-    });
+    const verifyProc = Bun.spawn(
+      ["git", "rev-parse", "--is-inside-work-tree"],
+      {
+        cwd: absPath,
+        stdout: "pipe",
+        stderr: "ignore",
+      },
+    );
     if ((await verifyProc.exited) !== 0) {
       throw new Error(`${absPath} is not a git repository`);
     }
@@ -65,12 +68,14 @@ async function indexPaths(paths: string[], indexPath: string): Promise<void> {
 }
 
 async function indexScan(config: Config, indexPath: string): Promise<void> {
-  const projectDir = expandTilde(config.projectDir);
+  const projectDir = effectiveProjectDir(config);
   const idx = await ProjectIndex.load(indexPath);
   const before = idx.list().length;
   await idx.additiveScan(projectDir);
   await idx.save(indexPath);
   const after = idx.list().length;
   const added = after - before;
-  console.error(`Found ${added} new project${added !== 1 ? "s" : ""} (${after} total)`);
+  console.error(
+    `Found ${added} new project${added !== 1 ? "s" : ""} (${after} total)`,
+  );
 }

--- a/src/commands/rebuild.ts
+++ b/src/commands/rebuild.ts
@@ -1,14 +1,14 @@
 import { ProjectIndex } from "../lib/index.ts";
-import { expandTilde } from "../lib/config.ts";
+import { effectiveProjectDir } from "../lib/config.ts";
 import type { Config } from "../types.ts";
 
 export async function rebuild(
   config: Config,
-  indexPath: string
+  indexPath: string,
 ): Promise<void> {
-  const projectDir = expandTilde(config.projectDir);
+  const projectDir = effectiveProjectDir(config);
   const idx = await ProjectIndex.load(indexPath);
-  await idx.rebuild(projectDir);
+  await idx.scopedRebuild(projectDir);
   await idx.save(indexPath);
   const count = idx.list().length;
   console.error(`Indexed ${count} projects`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { join } from "path";
 import { homedir } from "os";
-import { loadConfig, getConfigPath } from "./lib/config.ts";
+import { loadConfig, getConfigPath, getAgent } from "./lib/config.ts";
 import { cloneRepo } from "./commands/clone.ts";
 import { ls } from "./commands/ls.ts";
 import { resolve } from "./commands/resolve.ts";
@@ -57,6 +57,8 @@ Options:
   const configPath = getConfigPath();
   const indexPath = getIndexPath();
   const config = await loadConfig(configPath);
+  const agent = getAgent();
+  if (agent) console.error(`[gx agent: ${agent}]`);
 
   switch (command) {
     case "clone": {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,6 +15,22 @@ export function expandTilde(p: string): string {
   return p;
 }
 
+export function getAgent(): string | null {
+  const agent = process.env.GX_AGENT?.trim().toLowerCase() ?? null;
+  if (agent && !/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(agent)) {
+    throw new Error(
+      `Invalid GX_AGENT: "${agent}" — use lowercase alphanumeric and hyphens`,
+    );
+  }
+  return agent || null;
+}
+
+export function effectiveProjectDir(config: Config): string {
+  const base = expandTilde(config.projectDir);
+  const agent = getAgent();
+  return agent ? join(base, `.${agent}`) : base;
+}
+
 function validateConfig(raw: unknown): Config {
   if (typeof raw !== "object" || raw === null) {
     return { ...DEFAULT_CONFIG };
@@ -30,23 +46,20 @@ function validateConfig(raw: unknown): Config {
         ? obj.defaultHost
         : DEFAULT_CONFIG.defaultHost,
     structure:
-      obj.structure === "flat" || obj.structure === "owner" || obj.structure === "host"
+      obj.structure === "flat" ||
+      obj.structure === "owner" ||
+      obj.structure === "host"
         ? obj.structure
         : DEFAULT_CONFIG.structure,
     shallow:
-      typeof obj.shallow === "boolean"
-        ? obj.shallow
-        : DEFAULT_CONFIG.shallow,
+      typeof obj.shallow === "boolean" ? obj.shallow : DEFAULT_CONFIG.shallow,
     similarityThreshold:
       typeof obj.similarityThreshold === "number" &&
       obj.similarityThreshold >= 0 &&
       obj.similarityThreshold <= 1
         ? obj.similarityThreshold
         : DEFAULT_CONFIG.similarityThreshold,
-    editor:
-      typeof obj.editor === "string"
-        ? obj.editor
-        : DEFAULT_CONFIG.editor,
+    editor: typeof obj.editor === "string" ? obj.editor : DEFAULT_CONFIG.editor,
   };
 }
 
@@ -61,10 +74,7 @@ export async function loadConfig(path?: string): Promise<Config> {
   }
 }
 
-export async function saveConfig(
-  path: string,
-  config: Config
-): Promise<void> {
+export async function saveConfig(path: string, config: Config): Promise<void> {
   await mkdir(join(path, ".."), { recursive: true });
   await Bun.write(path, JSON.stringify(config, null, 2) + "\n");
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,7 +3,14 @@ import { mkdir, readdir, realpath, rename } from "fs/promises";
 import type { Index, IndexEntry } from "../types.ts";
 
 const MAX_SCAN_DEPTH = 10;
-const SKIP_DIRS = new Set(["node_modules", "vendor", "target", ".build", "dist", "build"]);
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "vendor",
+  "target",
+  ".build",
+  "dist",
+  "build",
+]);
 
 export class ProjectIndex {
   private data: Index;
@@ -33,7 +40,10 @@ export class ProjectIndex {
   }
 
   add(name: string, entry: IndexEntry): void {
-    if (this.data.projects[name] && this.data.projects[name].path !== entry.path) {
+    if (
+      this.data.projects[name] &&
+      this.data.projects[name].path !== entry.path
+    ) {
       console.error(
         `Warning: project name '${name}' collision — overwriting ${this.data.projects[name].path} with ${entry.path}`,
       );
@@ -73,6 +83,19 @@ export class ProjectIndex {
     this.data.projects = {};
     const visited = new Set<string>();
     await this.scanForRepos(projectDir, 0, visited);
+  }
+
+  async scopedRebuild(scopeDir: string): Promise<void> {
+    const prefix = scopeDir.endsWith("/") ? scopeDir : scopeDir + "/";
+    for (const [name, entry] of Object.entries(this.data.projects)) {
+      if (!entry.path.startsWith(prefix)) continue;
+      const rel = entry.path.slice(prefix.length);
+      const firstSegment = rel.split("/")[0];
+      if (firstSegment && firstSegment.startsWith(".")) continue;
+      delete this.data.projects[name];
+    }
+    const visited = new Set<string>();
+    await this.scanForRepos(scopeDir, 0, visited);
   }
 
   async additiveScan(projectDir: string): Promise<void> {
@@ -128,10 +151,11 @@ export class ProjectIndex {
 
   static async getRemoteUrl(repoPath: string): Promise<string> {
     try {
-      const proc = Bun.spawn(
-        ["git", "config", "--get", "remote.origin.url"],
-        { cwd: repoPath, stdout: "pipe", stderr: "ignore" },
-      );
+      const proc = Bun.spawn(["git", "config", "--get", "remote.origin.url"], {
+        cwd: repoPath,
+        stdout: "pipe",
+        stderr: "ignore",
+      });
       const exitCode = await proc.exited;
       if (exitCode !== 0) return "";
       const text = await new Response(proc.stdout).text();

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -1,9 +1,9 @@
 import { join } from "path";
 import type { ParsedRepo, Config } from "../types.ts";
-import { expandTilde } from "./config.ts";
+import { effectiveProjectDir } from "./config.ts";
 
 export function toPath(parsed: ParsedRepo, config: Config): string {
-  const base = expandTilde(config.projectDir);
+  const base = effectiveProjectDir(config);
   if (config.structure === "host") {
     return join(base, parsed.host, parsed.owner, parsed.repo);
   }

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -1,5 +1,11 @@
 import { test, expect, beforeEach, afterEach } from "bun:test";
-import { loadConfig, saveConfig, getConfigPath } from "../../src/lib/config.ts";
+import {
+  loadConfig,
+  saveConfig,
+  getConfigPath,
+  getAgent,
+  effectiveProjectDir,
+} from "../../src/lib/config.ts";
 import { DEFAULT_CONFIG } from "../../src/types.ts";
 import { join } from "path";
 import { mkdtemp, rm } from "fs/promises";
@@ -39,4 +45,91 @@ test("loadConfig merges partial config with defaults", async () => {
 test("getConfigPath returns ~/.config/gx/config.json", () => {
   const p = getConfigPath();
   expect(p).toContain(".config/gx/config.json");
+});
+
+// getAgent() tests
+
+test("getAgent returns null when GX_AGENT is not set", () => {
+  delete process.env.GX_AGENT;
+  expect(getAgent()).toBeNull();
+});
+
+test("getAgent returns lowercase agent name", () => {
+  process.env.GX_AGENT = "Morgan";
+  expect(getAgent()).toBe("morgan");
+  delete process.env.GX_AGENT;
+});
+
+test("getAgent trims whitespace", () => {
+  process.env.GX_AGENT = "  morgan  ";
+  expect(getAgent()).toBe("morgan");
+  delete process.env.GX_AGENT;
+});
+
+test("getAgent returns null for empty string", () => {
+  process.env.GX_AGENT = "";
+  expect(getAgent()).toBeNull();
+  delete process.env.GX_AGENT;
+});
+
+test("getAgent returns null for whitespace-only", () => {
+  process.env.GX_AGENT = "   ";
+  expect(getAgent()).toBeNull();
+  delete process.env.GX_AGENT;
+});
+
+test("getAgent accepts alphanumeric with hyphens", () => {
+  process.env.GX_AGENT = "agent-007";
+  expect(getAgent()).toBe("agent-007");
+  delete process.env.GX_AGENT;
+});
+
+test("getAgent throws on invalid characters", () => {
+  process.env.GX_AGENT = "bad_agent!";
+  expect(() => getAgent()).toThrow("Invalid GX_AGENT");
+  delete process.env.GX_AGENT;
+});
+
+test("getAgent throws on leading hyphen", () => {
+  process.env.GX_AGENT = "-morgan";
+  expect(() => getAgent()).toThrow("Invalid GX_AGENT");
+  delete process.env.GX_AGENT;
+});
+
+test("getAgent throws on trailing hyphen", () => {
+  process.env.GX_AGENT = "morgan-";
+  expect(() => getAgent()).toThrow("Invalid GX_AGENT");
+  delete process.env.GX_AGENT;
+});
+
+// effectiveProjectDir() tests
+
+test("effectiveProjectDir returns base dir when no agent", () => {
+  delete process.env.GX_AGENT;
+  const config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
+  expect(effectiveProjectDir(config)).toBe("/home/user/src");
+});
+
+test("effectiveProjectDir appends .agent when GX_AGENT set", () => {
+  process.env.GX_AGENT = "morgan";
+  const config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
+  expect(effectiveProjectDir(config)).toBe("/home/user/src/.morgan");
+  delete process.env.GX_AGENT;
+});
+
+test("effectiveProjectDir expands tilde", () => {
+  delete process.env.GX_AGENT;
+  const config = { ...DEFAULT_CONFIG, projectDir: "~/src" };
+  const result = effectiveProjectDir(config);
+  expect(result).not.toContain("~");
+  expect(result).toMatch(/\/src$/);
+});
+
+test("effectiveProjectDir expands tilde with agent", () => {
+  process.env.GX_AGENT = "morgan";
+  const config = { ...DEFAULT_CONFIG, projectDir: "~/src" };
+  const result = effectiveProjectDir(config);
+  expect(result).not.toContain("~");
+  expect(result).toMatch(/\/src\/\.morgan$/);
+  delete process.env.GX_AGENT;
 });

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -12,12 +12,20 @@ import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 
 let tmpDir: string;
+let savedGxAgent: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), "gx-test-"));
+  savedGxAgent = process.env.GX_AGENT;
+  delete process.env.GX_AGENT;
 });
 
 afterEach(async () => {
+  if (savedGxAgent !== undefined) {
+    process.env.GX_AGENT = savedGxAgent;
+  } else {
+    delete process.env.GX_AGENT;
+  }
   await rm(tmpDir, { recursive: true });
 });
 
@@ -50,62 +58,52 @@ test("getConfigPath returns ~/.config/gx/config.json", () => {
 // getAgent() tests
 
 test("getAgent returns null when GX_AGENT is not set", () => {
-  delete process.env.GX_AGENT;
   expect(getAgent()).toBeNull();
 });
 
 test("getAgent returns lowercase agent name", () => {
   process.env.GX_AGENT = "Morgan";
   expect(getAgent()).toBe("morgan");
-  delete process.env.GX_AGENT;
 });
 
 test("getAgent trims whitespace", () => {
   process.env.GX_AGENT = "  morgan  ";
   expect(getAgent()).toBe("morgan");
-  delete process.env.GX_AGENT;
 });
 
 test("getAgent returns null for empty string", () => {
   process.env.GX_AGENT = "";
   expect(getAgent()).toBeNull();
-  delete process.env.GX_AGENT;
 });
 
 test("getAgent returns null for whitespace-only", () => {
   process.env.GX_AGENT = "   ";
   expect(getAgent()).toBeNull();
-  delete process.env.GX_AGENT;
 });
 
 test("getAgent accepts alphanumeric with hyphens", () => {
   process.env.GX_AGENT = "agent-007";
   expect(getAgent()).toBe("agent-007");
-  delete process.env.GX_AGENT;
 });
 
 test("getAgent throws on invalid characters", () => {
   process.env.GX_AGENT = "bad_agent!";
   expect(() => getAgent()).toThrow("Invalid GX_AGENT");
-  delete process.env.GX_AGENT;
 });
 
 test("getAgent throws on leading hyphen", () => {
   process.env.GX_AGENT = "-morgan";
   expect(() => getAgent()).toThrow("Invalid GX_AGENT");
-  delete process.env.GX_AGENT;
 });
 
 test("getAgent throws on trailing hyphen", () => {
   process.env.GX_AGENT = "morgan-";
   expect(() => getAgent()).toThrow("Invalid GX_AGENT");
-  delete process.env.GX_AGENT;
 });
 
 // effectiveProjectDir() tests
 
 test("effectiveProjectDir returns base dir when no agent", () => {
-  delete process.env.GX_AGENT;
   const config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
   expect(effectiveProjectDir(config)).toBe("/home/user/src");
 });
@@ -114,11 +112,9 @@ test("effectiveProjectDir appends .agent when GX_AGENT set", () => {
   process.env.GX_AGENT = "morgan";
   const config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
   expect(effectiveProjectDir(config)).toBe("/home/user/src/.morgan");
-  delete process.env.GX_AGENT;
 });
 
 test("effectiveProjectDir expands tilde", () => {
-  delete process.env.GX_AGENT;
   const config = { ...DEFAULT_CONFIG, projectDir: "~/src" };
   const result = effectiveProjectDir(config);
   expect(result).not.toContain("~");
@@ -131,5 +127,4 @@ test("effectiveProjectDir expands tilde with agent", () => {
   const result = effectiveProjectDir(config);
   expect(result).not.toContain("~");
   expect(result).toMatch(/\/src\/\.morgan$/);
-  delete process.env.GX_AGENT;
 });

--- a/tests/lib/index.test.ts
+++ b/tests/lib/index.test.ts
@@ -23,7 +23,11 @@ test("load returns empty index when file missing", async () => {
 
 test("add and resolve a project", async () => {
   const idx = await ProjectIndex.load(indexPath);
-  idx.add("gx", { path: "/home/user/src/joshuaboys/gx", url: "https://github.com/joshuaboys/gx", clonedAt: "2026-02-23T00:00:00Z" });
+  idx.add("gx", {
+    path: "/home/user/src/joshuaboys/gx",
+    url: "https://github.com/joshuaboys/gx",
+    clonedAt: "2026-02-23T00:00:00Z",
+  });
   expect(idx.resolve("gx")).toBe("/home/user/src/joshuaboys/gx");
 });
 
@@ -34,7 +38,11 @@ test("resolve returns null for unknown project", async () => {
 
 test("save persists and load reads back", async () => {
   const idx = await ProjectIndex.load(indexPath);
-  idx.add("gx", { path: "/tmp/gx", url: "https://github.com/joshuaboys/gx", clonedAt: "2026-02-23T00:00:00Z" });
+  idx.add("gx", {
+    path: "/tmp/gx",
+    url: "https://github.com/joshuaboys/gx",
+    clonedAt: "2026-02-23T00:00:00Z",
+  });
   await idx.save(indexPath);
 
   const idx2 = await ProjectIndex.load(indexPath);
@@ -61,13 +69,20 @@ test("getRemoteUrl returns origin URL for a local repo with origin configured", 
   const repoDir = join(tmpDir, "fixture-repo");
   await mkdir(repoDir, { recursive: true });
 
-  let proc = Bun.spawn(["git", "init"], { cwd: repoDir, stdout: "ignore", stderr: "ignore" });
-  await proc.exited;
-  proc = Bun.spawn(["git", "remote", "add", "origin", "https://github.com/joshuaboys/gx.git"], {
+  let proc = Bun.spawn(["git", "init"], {
     cwd: repoDir,
     stdout: "ignore",
     stderr: "ignore",
   });
+  await proc.exited;
+  proc = Bun.spawn(
+    ["git", "remote", "add", "origin", "https://github.com/joshuaboys/gx.git"],
+    {
+      cwd: repoDir,
+      stdout: "ignore",
+      stderr: "ignore",
+    },
+  );
   await proc.exited;
 
   const url = await ProjectIndex.getRemoteUrl(repoDir);
@@ -81,7 +96,11 @@ test("getRemoteUrl returns empty string for non-repo", async () => {
 
 test("merge adds a new project and returns true", async () => {
   const idx = await ProjectIndex.load(indexPath);
-  const isNew = idx.merge("newrepo", { path: "/tmp/newrepo", url: "https://github.com/user/newrepo", clonedAt: "2026-03-02T00:00:00Z" });
+  const isNew = idx.merge("newrepo", {
+    path: "/tmp/newrepo",
+    url: "https://github.com/user/newrepo",
+    clonedAt: "2026-03-02T00:00:00Z",
+  });
   expect(isNew).toBe(true);
   expect(idx.resolve("newrepo")).toBe("/tmp/newrepo");
 });
@@ -89,14 +108,22 @@ test("merge adds a new project and returns true", async () => {
 test("merge skips when name and path already match", async () => {
   const idx = await ProjectIndex.load(indexPath);
   idx.add("myrepo", { path: "/tmp/myrepo", url: "", clonedAt: "" });
-  const isNew = idx.merge("myrepo", { path: "/tmp/myrepo", url: "https://github.com/user/myrepo", clonedAt: "2026-03-02T00:00:00Z" });
+  const isNew = idx.merge("myrepo", {
+    path: "/tmp/myrepo",
+    url: "https://github.com/user/myrepo",
+    clonedAt: "2026-03-02T00:00:00Z",
+  });
   expect(isNew).toBe(false);
 });
 
 test("merge overwrites when name exists but path differs", async () => {
   const idx = await ProjectIndex.load(indexPath);
   idx.add("myrepo", { path: "/old/myrepo", url: "", clonedAt: "" });
-  const isNew = idx.merge("myrepo", { path: "/new/myrepo", url: "", clonedAt: "" });
+  const isNew = idx.merge("myrepo", {
+    path: "/new/myrepo",
+    url: "",
+    clonedAt: "",
+  });
   expect(isNew).toBe(true);
   expect(idx.resolve("myrepo")).toBe("/new/myrepo");
 });
@@ -105,13 +132,20 @@ test("scanForRepos populates remote URL when available", async () => {
   const repoDir = join(tmpDir, "testorg", "gx");
   await mkdir(repoDir, { recursive: true });
 
-  let proc = Bun.spawn(["git", "init"], { cwd: repoDir, stdout: "ignore", stderr: "ignore" });
-  await proc.exited;
-  proc = Bun.spawn(["git", "remote", "add", "origin", "https://github.com/joshuaboys/gx.git"], {
+  let proc = Bun.spawn(["git", "init"], {
     cwd: repoDir,
     stdout: "ignore",
     stderr: "ignore",
   });
+  await proc.exited;
+  proc = Bun.spawn(
+    ["git", "remote", "add", "origin", "https://github.com/joshuaboys/gx.git"],
+    {
+      cwd: repoDir,
+      stdout: "ignore",
+      stderr: "ignore",
+    },
+  );
   await proc.exited;
   await mkdir(join(repoDir, ".git"), { recursive: true });
 
@@ -152,4 +186,83 @@ test("rebuild scans directory for git repos", async () => {
   await idx.rebuild(tmpDir);
   expect(idx.resolve("repoA")).toBe(join(tmpDir, "user", "repoA"));
   expect(idx.resolve("repoB")).toBe(join(tmpDir, "user", "repoB"));
+});
+
+// scopedRebuild() tests
+
+test("scopedRebuild deletes entries under scope and rescans", async () => {
+  await mkdir(join(tmpDir, "org", "repoA", ".git"), { recursive: true });
+  await mkdir(join(tmpDir, "org", "repoB", ".git"), { recursive: true });
+
+  const idx = await ProjectIndex.load(indexPath);
+  // Pre-populate with an out-of-scope entry
+  idx.add("external", { path: "/other/dir/external", url: "", clonedAt: "" });
+  // Add an in-scope entry that will be wiped and re-discovered
+  idx.add("repoA", {
+    path: join(tmpDir, "org", "repoA"),
+    url: "",
+    clonedAt: "",
+  });
+
+  await idx.scopedRebuild(tmpDir);
+
+  // External entry preserved (not under tmpDir)
+  expect(idx.resolve("external")).toBe("/other/dir/external");
+  // In-scope entries rediscovered
+  expect(idx.resolve("repoA")).toBe(join(tmpDir, "org", "repoA"));
+  expect(idx.resolve("repoB")).toBe(join(tmpDir, "org", "repoB"));
+});
+
+test("scopedRebuild skips dotdir entries during deletion", async () => {
+  // Simulate agent repos under a dotdir
+  const agentDir = join(tmpDir, ".morgan");
+  await mkdir(join(agentDir, "org", "agentrepo", ".git"), { recursive: true });
+  // Simulate user repos
+  await mkdir(join(tmpDir, "org", "userrepo", ".git"), { recursive: true });
+
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("agentrepo", {
+    path: join(agentDir, "org", "agentrepo"),
+    url: "",
+    clonedAt: "",
+  });
+  idx.add("userrepo", {
+    path: join(tmpDir, "org", "userrepo"),
+    url: "",
+    clonedAt: "",
+  });
+
+  // User scoped rebuild (scope = tmpDir) should NOT delete agent entries
+  await idx.scopedRebuild(tmpDir);
+
+  // Agent entry preserved (dotdir prefix)
+  expect(idx.resolve("agentrepo")).toBe(join(agentDir, "org", "agentrepo"));
+  // User entry re-discovered
+  expect(idx.resolve("userrepo")).toBe(join(tmpDir, "org", "userrepo"));
+});
+
+test("scopedRebuild from agent scope only affects agent entries", async () => {
+  const agentDir = join(tmpDir, ".morgan");
+  await mkdir(join(agentDir, "org", "agentrepo", ".git"), { recursive: true });
+  await mkdir(join(tmpDir, "org", "userrepo", ".git"), { recursive: true });
+
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("agentrepo", {
+    path: join(agentDir, "org", "agentrepo"),
+    url: "",
+    clonedAt: "",
+  });
+  idx.add("userrepo", {
+    path: join(tmpDir, "org", "userrepo"),
+    url: "",
+    clonedAt: "",
+  });
+
+  // Agent scoped rebuild (scope = agentDir)
+  await idx.scopedRebuild(agentDir);
+
+  // User entry preserved (not under agentDir)
+  expect(idx.resolve("userrepo")).toBe(join(tmpDir, "org", "userrepo"));
+  // Agent entry re-discovered
+  expect(idx.resolve("agentrepo")).toBe(join(agentDir, "org", "agentrepo"));
 });

--- a/tests/lib/path.test.ts
+++ b/tests/lib/path.test.ts
@@ -1,7 +1,22 @@
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach, afterEach } from "bun:test";
 import { toPath } from "../../src/lib/path.ts";
 import type { ParsedRepo, Config } from "../../src/types.ts";
 import { DEFAULT_CONFIG } from "../../src/types.ts";
+
+let savedGxAgent: string | undefined;
+
+beforeEach(() => {
+  savedGxAgent = process.env.GX_AGENT;
+  delete process.env.GX_AGENT;
+});
+
+afterEach(() => {
+  if (savedGxAgent !== undefined) {
+    process.env.GX_AGENT = savedGxAgent;
+  } else {
+    delete process.env.GX_AGENT;
+  }
+});
 
 const repo: ParsedRepo = {
   host: "github.com",
@@ -54,7 +69,6 @@ test("owner structure with GX_AGENT routes to dotdir", () => {
   process.env.GX_AGENT = "morgan";
   const config: Config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
   expect(toPath(repo, config)).toBe("/home/user/src/.morgan/juev/gclone");
-  delete process.env.GX_AGENT;
 });
 
 test("flat structure with GX_AGENT routes to dotdir", () => {
@@ -65,7 +79,6 @@ test("flat structure with GX_AGENT routes to dotdir", () => {
     structure: "flat",
   };
   expect(toPath(repo, config)).toBe("/home/user/src/.morgan/gclone");
-  delete process.env.GX_AGENT;
 });
 
 test("host structure with GX_AGENT routes to dotdir", () => {
@@ -78,11 +91,9 @@ test("host structure with GX_AGENT routes to dotdir", () => {
   expect(toPath(repo, config)).toBe(
     "/home/user/src/.morgan/github.com/juev/gclone",
   );
-  delete process.env.GX_AGENT;
 });
 
 test("no GX_AGENT produces normal path", () => {
-  delete process.env.GX_AGENT;
   const config: Config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
   expect(toPath(repo, config)).toBe("/home/user/src/juev/gclone");
 });

--- a/tests/lib/path.test.ts
+++ b/tests/lib/path.test.ts
@@ -49,3 +49,40 @@ test("tilde expansion in projectDir", () => {
   expect(result).not.toContain("~");
   expect(result).toContain("/juev/gclone");
 });
+
+test("owner structure with GX_AGENT routes to dotdir", () => {
+  process.env.GX_AGENT = "morgan";
+  const config: Config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
+  expect(toPath(repo, config)).toBe("/home/user/src/.morgan/juev/gclone");
+  delete process.env.GX_AGENT;
+});
+
+test("flat structure with GX_AGENT routes to dotdir", () => {
+  process.env.GX_AGENT = "morgan";
+  const config: Config = {
+    ...DEFAULT_CONFIG,
+    projectDir: "/home/user/src",
+    structure: "flat",
+  };
+  expect(toPath(repo, config)).toBe("/home/user/src/.morgan/gclone");
+  delete process.env.GX_AGENT;
+});
+
+test("host structure with GX_AGENT routes to dotdir", () => {
+  process.env.GX_AGENT = "morgan";
+  const config: Config = {
+    ...DEFAULT_CONFIG,
+    projectDir: "/home/user/src",
+    structure: "host",
+  };
+  expect(toPath(repo, config)).toBe(
+    "/home/user/src/.morgan/github.com/juev/gclone",
+  );
+  delete process.env.GX_AGENT;
+});
+
+test("no GX_AGENT produces normal path", () => {
+  delete process.env.GX_AGENT;
+  const config: Config = { ...DEFAULT_CONFIG, projectDir: "/home/user/src" };
+  expect(toPath(repo, config)).toBe("/home/user/src/juev/gclone");
+});


### PR DESCRIPTION
## Summary

- Adds `GX_AGENT` env var support for routing agent clones to `{projectDir}/.{agent}/owner/repo`
- Dot-prefixed directories hide agent repos from `ls` and gx's scanner
- Scoped rebuild ensures user rebuilds don't wipe agent entries and vice versa (dotdir-aware prefix matching)
- `gx config` shows agent and effective project dir when `GX_AGENT` is set
- Startup prints `[gx agent: morgan]` indicator to stderr

## Changed files

- `src/lib/config.ts` — `getAgent()` (validates env var) + `effectiveProjectDir()`
- `src/lib/index.ts` — `scopedRebuild()` with dotdir-aware deletion
- `src/lib/path.ts` — `toPath()` uses `effectiveProjectDir`
- `src/commands/rebuild.ts` — uses scoped rebuild
- `src/commands/index-repos.ts` — `indexScan` uses `effectiveProjectDir`
- `src/commands/config.ts` — shows agent info in `gx config`
- `src/index.ts` — agent startup indicator

## Test plan

- [x] 12 new tests for `getAgent()` and `effectiveProjectDir()` (validation, tilde expansion, agent routing)
- [x] 3 new tests for `scopedRebuild()` (scoped deletion, dotdir preservation, cross-scope isolation)
- [x] 4 new tests for `toPath()` with agent (all structure modes + no-agent baseline)
- [x] All 177 tests pass, types clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)