### PR TITLE
feat(tracking): add project visit tracking, gx recent, and gx resume

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,5 @@
 #!/bin/sh
 set -e
 
-if [ -f "$(dirname -- "$0")/_/husky.sh" ]; then
-  . "$(dirname -- "$0")/_/husky.sh"
-fi
-
 bun x tsc --noEmit
 bun x lint-staged

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # gx
 
-**A fast git project manager. 
+**A fast git project manager.
 Clone, jump, and organise repos from the terminal.**
 
 [![CI](https://github.com/joshuaboys/gx/actions/workflows/ci.yml/badge.svg)](https://github.com/joshuaboys/gx/actions/workflows/ci.yml)
@@ -206,13 +206,6 @@ Remove the `# gx` block from your shell config file (`~/.zshrc`, `~/.bashrc`, or
 
 - [Use cases & examples](docs/use-cases.md) — real-world workflows, scripting recipes, and shell aliases
 - [Contributing](CONTRIBUTING.md) — development setup and guidelines
-
-## Acknowledgements
-
-gx draws inspiration from these projects:
-
-- **[ghq](https://github.com/x-motemen/ghq)** — the original structured repository manager. ghq pioneered the `host/owner/repo` directory layout and index-based project lookup that gx builds on.
-- **[gclone](https://github.com/allonsy/gclone)** — a git clone helper with automatic directory organisation, shorthand URL parsing, and shell auto-cd. gx's clone workflow and shell integration owe a lot to gclone's approach.
 
 ## Acknowledgements
 

--- a/docs/plans/2026-03-04-tracking-design.md
+++ b/docs/plans/2026-03-04-tracking-design.md
@@ -1,0 +1,94 @@
+# Tracking Feature Design
+
+**Date:** 2026-03-04
+**Module:** 09-tracking
+**Branch:** feat/tracking
+
+## Problem
+
+gx has no memory of which projects you use. After cloning 50+ repos, there's no way to see what you worked on recently or quickly resume where you left off with context.
+
+## Approach
+
+Add tracking directly to the index (Approach A). `lastVisited` is an index concern — no separate tracking module. `resolve` updates the timestamp as a side effect, eliminating the need for a separate `touch` command.
+
+## Data Model
+
+`IndexEntry` gains one optional field:
+
+```typescript
+export interface IndexEntry {
+  path: string;
+  url: string;
+  clonedAt: string;
+  lastVisited?: string; // ISO 8601, absent = never visited
+}
+```
+
+Backward compatible — existing index.json files load without migration.
+
+## Index Changes
+
+Two new methods on `ProjectIndex`:
+
+- **`touch(name: string): boolean`** — sets `lastVisited` to now. Returns false if entry not found. (Internal method, no CLI command.)
+- **`recent(limit?: number): Array<[string, IndexEntry]>`** — entries sorted by `lastVisited` descending, falling back to `clonedAt` for unvisited entries.
+
+## Command Changes
+
+### resolve (modified)
+
+`resolve` now calls `touch(name)` and saves the index after resolving. This records visits without a separate subprocess.
+
+### gx recent [-n N] (new)
+
+Lists projects sorted by most recently visited. Defaults to all; `-n N` limits output. Displays relative timestamps ("2 hours ago", "3 days ago").
+
+### gx resume \<name\> (new)
+
+Resolves project path, prints git context, outputs path for shell cd. Calls `touch` internally.
+
+Output format:
+
+```
+myproject (feat/auth) — 3 dirty files
+  Last commit: a1b2c3d fix: handle empty token (2 hours ago)
+```
+
+Git queries: `git branch --show-current`, `git status --porcelain`, `git log -1 --format='%h %s (%cr)'`.
+
+### clone (modified)
+
+Sets `lastVisited` to same value as `clonedAt` on creation.
+
+## Shell Integration
+
+No shell changes needed for tracking — `resolve` handles it. Shell wrapper updated for `resume`:
+
+```bash
+resume)
+    local output
+    output=$("$_GX_BIN" resume "${@:2}")
+    local target
+    target=$(echo "$output" | tail -1)
+    echo "$output" | head -n -1
+    if [ -n "$target" ] && [ -d "$target" ]; then
+        cd "$target"
+    fi
+    ;;
+```
+
+Tab completion arrays get `recent` and `resume` added.
+
+## Error Handling
+
+- `gx recent` with no visits: falls back to `clonedAt` ordering
+- `gx resume` with deleted directory: `"project 'x' directory not found: /path"`, exit 1
+- `gx resume` with unknown name: `"project 'x' not found in index"`, exit 1
+
+## Out of Scope
+
+- Frecency scoring (recency only)
+- Automatic stale entry pruning
+- Duration tracking
+- Shell prompt integration

--- a/docs/plans/2026-03-04-tracking-implementation.md
+++ b/docs/plans/2026-03-04-tracking-implementation.md
@@ -1,0 +1,974 @@
+# Tracking Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add project visit tracking to gx — `lastVisited` timestamps, `gx recent`, and `gx resume`.
+
+**Architecture:** Extend `IndexEntry` with an optional `lastVisited` field. `resolve` updates it as a side effect (no separate `touch` command). Two new commands (`recent`, `resume`) and a relative-time utility.
+
+**Tech Stack:** TypeScript, Bun, bun:test
+
+---
+
+### Task 1: Add `lastVisited` to IndexEntry type
+
+**Files:**
+
+- Modify: `src/types.ts:26-30`
+
+**Step 1: Write the type change**
+
+In `src/types.ts`, add `lastVisited` to `IndexEntry`:
+
+```typescript
+export interface IndexEntry {
+  path: string;
+  url: string;
+  clonedAt: string;
+  lastVisited?: string;
+}
+```
+
+**Step 2: Verify types compile**
+
+Run: `bun x tsc --noEmit`
+Expected: PASS (no errors — field is optional, so all existing code is compatible)
+
+**Step 3: Run existing tests to confirm no regressions**
+
+Run: `bun test`
+Expected: All existing tests pass unchanged.
+
+**Step 4: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat(tracking): add lastVisited field to IndexEntry"
+```
+
+---
+
+### Task 2: Add `touch()` and `recent()` methods to ProjectIndex
+
+**Files:**
+
+- Modify: `src/lib/index.ts:15` (inside `ProjectIndex` class)
+- Test: `tests/lib/index.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add to `tests/lib/index.test.ts`:
+
+```typescript
+test("touch updates lastVisited on existing entry", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("gx", {
+    path: "/tmp/gx",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+  });
+  const before = new Date().toISOString();
+  const found = idx.touch("gx");
+  const after = new Date().toISOString();
+  expect(found).toBe(true);
+  const entry = idx.list().find((e) => e.name === "gx");
+  expect(entry!.lastVisited).toBeDefined();
+  expect(entry!.lastVisited! >= before).toBe(true);
+  expect(entry!.lastVisited! <= after).toBe(true);
+});
+
+test("touch returns false for unknown project", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  expect(idx.touch("nope")).toBe(false);
+});
+
+test("recent returns entries sorted by lastVisited descending", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("old", {
+    path: "/tmp/old",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+    lastVisited: "2026-01-01T00:00:00Z",
+  });
+  idx.add("new", {
+    path: "/tmp/new",
+    url: "",
+    clonedAt: "2026-01-02T00:00:00Z",
+    lastVisited: "2026-03-01T00:00:00Z",
+  });
+  idx.add("mid", {
+    path: "/tmp/mid",
+    url: "",
+    clonedAt: "2026-01-03T00:00:00Z",
+    lastVisited: "2026-02-01T00:00:00Z",
+  });
+  const result = idx.recent();
+  expect(result.map(([name]) => name)).toEqual(["new", "mid", "old"]);
+});
+
+test("recent falls back to clonedAt when lastVisited is absent", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("visited", {
+    path: "/tmp/visited",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+    lastVisited: "2026-02-01T00:00:00Z",
+  });
+  idx.add("unvisited", {
+    path: "/tmp/unvisited",
+    url: "",
+    clonedAt: "2026-03-01T00:00:00Z",
+  });
+  const result = idx.recent();
+  // unvisited has clonedAt 2026-03-01 > visited's lastVisited 2026-02-01
+  expect(result.map(([name]) => name)).toEqual(["unvisited", "visited"]);
+});
+
+test("recent respects limit parameter", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("a", {
+    path: "/tmp/a",
+    url: "",
+    clonedAt: "",
+    lastVisited: "2026-03-03T00:00:00Z",
+  });
+  idx.add("b", {
+    path: "/tmp/b",
+    url: "",
+    clonedAt: "",
+    lastVisited: "2026-03-02T00:00:00Z",
+  });
+  idx.add("c", {
+    path: "/tmp/c",
+    url: "",
+    clonedAt: "",
+    lastVisited: "2026-03-01T00:00:00Z",
+  });
+  const result = idx.recent(2);
+  expect(result).toHaveLength(2);
+  expect(result.map(([name]) => name)).toEqual(["a", "b"]);
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/lib/index.test.ts`
+Expected: FAIL — `touch` and `recent` methods don't exist yet.
+
+**Step 3: Implement `touch()` and `recent()`**
+
+Add these methods to the `ProjectIndex` class in `src/lib/index.ts`, after the `resolve` method (around line 70):
+
+```typescript
+touch(name: string): boolean {
+  const entry = this.data.projects[name];
+  if (!entry) return false;
+  entry.lastVisited = new Date().toISOString();
+  return true;
+}
+
+recent(limit?: number): Array<[string, IndexEntry]> {
+  const entries = Object.entries(this.data.projects).sort((a, b) => {
+    const timeA = a[1].lastVisited || a[1].clonedAt || "";
+    const timeB = b[1].lastVisited || b[1].clonedAt || "";
+    return timeB.localeCompare(timeA);
+  });
+  return limit ? entries.slice(0, limit) : entries;
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/lib/index.test.ts`
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/index.ts tests/lib/index.test.ts
+git commit -m "feat(tracking): add touch() and recent() to ProjectIndex"
+```
+
+---
+
+### Task 3: Add relative time utility
+
+**Files:**
+
+- Create: `src/lib/time.ts`
+- Test: `tests/lib/time.test.ts`
+
+**Step 1: Write the failing test**
+
+Create `tests/lib/time.test.ts`:
+
+```typescript
+import { test, expect } from "bun:test";
+import { relativeTime } from "../../src/lib/time.ts";
+
+test("returns 'just now' for timestamps within 60 seconds", () => {
+  const now = new Date();
+  expect(relativeTime(now.toISOString())).toBe("just now");
+});
+
+test("returns minutes ago", () => {
+  const t = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("5 minutes ago");
+});
+
+test("returns '1 minute ago' for singular", () => {
+  const t = new Date(Date.now() - 90 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("1 minute ago");
+});
+
+test("returns hours ago", () => {
+  const t = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("3 hours ago");
+});
+
+test("returns days ago", () => {
+  const t = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("2 days ago");
+});
+
+test("returns weeks ago", () => {
+  const t = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("2 weeks ago");
+});
+
+test("returns months ago", () => {
+  const t = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("2 months ago");
+});
+
+test("returns empty string for empty input", () => {
+  expect(relativeTime("")).toBe("");
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/lib/time.test.ts`
+Expected: FAIL — module doesn't exist.
+
+**Step 3: Implement relativeTime**
+
+Create `src/lib/time.ts`:
+
+```typescript
+export function relativeTime(iso: string): string {
+  if (!iso) return "";
+  const diff = Date.now() - new Date(iso).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60)
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 14) return `${days} ${days === 1 ? "day" : "days"} ago`;
+  const weeks = Math.floor(days / 7);
+  if (days < 60) return `${weeks} ${weeks === 1 ? "week" : "weeks"} ago`;
+  const months = Math.floor(days / 30);
+  return `${months} ${months === 1 ? "month" : "months"} ago`;
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bun test tests/lib/time.test.ts`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/time.ts tests/lib/time.test.ts
+git commit -m "feat(tracking): add relativeTime utility"
+```
+
+---
+
+### Task 4: Update `resolve` to record visits
+
+**Files:**
+
+- Modify: `src/commands/resolve.ts`
+- Test: `tests/commands/resolve.test.ts` (create if not exists)
+
+**Step 1: Write the failing test**
+
+Create `tests/commands/resolve.test.ts`:
+
+```typescript
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { ProjectIndex } from "../../src/lib/index.ts";
+import { join } from "path";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "gx-test-"));
+  indexPath = join(tmpDir, "index.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true });
+});
+
+test("resolve updates lastVisited on exact match", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("gx", {
+    path: "/tmp/gx",
+    url: "https://github.com/joshuaboys/gx",
+    clonedAt: "2026-01-01T00:00:00Z",
+  });
+  await idx.save(indexPath);
+
+  // Call resolve — it should update lastVisited and save
+  // We need to capture stdout and suppress process.exit
+  // Instead, test the index method integration directly:
+  const idx2 = await ProjectIndex.load(indexPath);
+  const found = idx2.touch("gx");
+  expect(found).toBe(true);
+  await idx2.save(indexPath);
+
+  const idx3 = await ProjectIndex.load(indexPath);
+  const entry = idx3.list().find((e) => e.name === "gx");
+  expect(entry!.lastVisited).toBeDefined();
+});
+```
+
+Note: Full integration testing of the `resolve` command with stdout/stderr capture is harder in bun:test. The unit test on `touch()` in Task 2 covers the core logic. This test verifies the save-and-reload cycle.
+
+**Step 2: Modify `src/commands/resolve.ts`**
+
+Update `resolve` to call `touch` and save after a successful match (exact or fuzzy auto-jump):
+
+```typescript
+import { ProjectIndex } from "../lib/index.ts";
+import { fuzzyMatch } from "../lib/fuzzy.ts";
+import type { Config } from "../types.ts";
+
+const AUTO_JUMP_THRESHOLD = 0.85;
+
+export async function resolve(
+  name: string,
+  indexPath: string,
+  config: Config,
+  listAll = false,
+): Promise<void> {
+  const idx = await ProjectIndex.load(indexPath);
+
+  if (listAll) {
+    console.log(idx.names().join("\n"));
+    return;
+  }
+
+  // Try exact match first
+  const path = idx.resolve(name);
+  if (path) {
+    idx.touch(name);
+    await idx.save(indexPath);
+    console.log(path);
+    return;
+  }
+
+  // Fall back to fuzzy matching
+  const entries = idx.list().map((e) => ({ name: e.name, path: e.path }));
+  const matches = fuzzyMatch(name, entries, config.similarityThreshold);
+
+  if (matches.length === 0) {
+    console.error(`Project '${name}' not found`);
+    process.exit(1);
+  }
+
+  const first = matches[0];
+  if (matches.length === 1 && first && first.score >= AUTO_JUMP_THRESHOLD) {
+    console.error(
+      `Fuzzy match: '${name}' -> '${first.name}' (${(first.score * 100).toFixed(0)}%)`,
+    );
+    idx.touch(first.name);
+    await idx.save(indexPath);
+    console.log(first.path);
+    return;
+  }
+
+  // Multiple candidates or single low-confidence match: show list
+  console.error(`No exact match for '${name}'. Did you mean:`);
+  for (const [i, m] of matches.entries()) {
+    console.error(`  ${i + 1}. ${m.name} (${(m.score * 100).toFixed(0)}%)`);
+  }
+  process.exit(1);
+}
+```
+
+**Step 3: Run all tests**
+
+Run: `bun test`
+Expected: All pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/commands/resolve.ts tests/commands/resolve.test.ts
+git commit -m "feat(tracking): update resolve to record lastVisited"
+```
+
+---
+
+### Task 5: Update `clone` to set `lastVisited`
+
+**Files:**
+
+- Modify: `src/commands/clone.ts:54-58`
+
+**Step 1: Update clone to include lastVisited**
+
+In `src/commands/clone.ts`, change the `idx.add()` call to include `lastVisited`:
+
+```typescript
+const now = new Date().toISOString();
+idx.add(parsed.repo, {
+  path: targetDir,
+  url: cloneUrl,
+  clonedAt: now,
+  lastVisited: now,
+});
+```
+
+**Step 2: Run all tests**
+
+Run: `bun test`
+Expected: All pass.
+
+**Step 3: Commit**
+
+```bash
+git add src/commands/clone.ts
+git commit -m "feat(tracking): set lastVisited on clone"
+```
+
+---
+
+### Task 6: Add `gx recent` command
+
+**Files:**
+
+- Create: `src/commands/recent.ts`
+- Create: `tests/commands/recent.test.ts`
+- Modify: `src/index.ts` (add case for "recent")
+
+**Step 1: Write the failing test**
+
+Create `tests/commands/recent.test.ts`:
+
+```typescript
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { ProjectIndex } from "../../src/lib/index.ts";
+import { join } from "path";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "gx-test-"));
+  indexPath = join(tmpDir, "index.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true });
+});
+
+test("recent lists projects sorted by lastVisited", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("old", {
+    path: "/tmp/old",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+    lastVisited: "2026-01-01T00:00:00Z",
+  });
+  idx.add("new", {
+    path: "/tmp/new",
+    url: "",
+    clonedAt: "2026-01-02T00:00:00Z",
+    lastVisited: "2026-03-01T00:00:00Z",
+  });
+  await idx.save(indexPath);
+
+  const result = idx.recent();
+  expect(result[0][0]).toBe("new");
+  expect(result[1][0]).toBe("old");
+});
+
+test("recent with empty index produces no output", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  const result = idx.recent();
+  expect(result).toHaveLength(0);
+});
+```
+
+**Step 2: Run tests to verify they pass**
+
+These tests use `idx.recent()` which was implemented in Task 2, so they should already pass:
+
+Run: `bun test tests/commands/recent.test.ts`
+Expected: PASS.
+
+**Step 3: Create the recent command handler**
+
+Create `src/commands/recent.ts`:
+
+```typescript
+import { ProjectIndex } from "../lib/index.ts";
+import { relativeTime } from "../lib/time.ts";
+
+export async function recent(indexPath: string, limit?: number): Promise<void> {
+  const idx = await ProjectIndex.load(indexPath);
+  const entries = idx.recent(limit);
+
+  if (entries.length === 0) {
+    console.error("No projects indexed. Clone a repo or run 'gx rebuild'.");
+    return;
+  }
+
+  const maxName = Math.max(...entries.map(([name]) => name.length));
+  for (const [name, entry] of entries) {
+    const time = relativeTime(entry.lastVisited || entry.clonedAt);
+    const timeStr = time ? `  ${time}` : "";
+    console.log(`${name.padEnd(maxName)}  ${entry.path}${timeStr}`);
+  }
+}
+```
+
+**Step 4: Wire into CLI**
+
+In `src/index.ts`, add the import at the top:
+
+```typescript
+import { recent } from "./commands/recent.ts";
+```
+
+Add this case in the switch statement, before `default`:
+
+```typescript
+    case "recent": {
+      const nFlag = args.indexOf("-n");
+      let limit: number | undefined;
+      if (nFlag >= 0 && args[nFlag + 1]) {
+        limit = parseInt(args[nFlag + 1], 10);
+        if (isNaN(limit) || limit < 1) {
+          console.error("Usage: gx recent [-n <count>]");
+          process.exit(1);
+        }
+      }
+      await recent(indexPath, limit);
+      break;
+    }
+```
+
+Also update the help text in the `--help` block to include:
+
+```
+  gx recent              List recently visited projects
+  gx recent -n <N>       Show last N projects
+```
+
+**Step 5: Run all tests**
+
+Run: `bun test`
+Expected: All pass.
+
+**Step 6: Commit**
+
+```bash
+git add src/commands/recent.ts tests/commands/recent.test.ts src/index.ts
+git commit -m "feat(tracking): add gx recent command"
+```
+
+---
+
+### Task 7: Add `gx resume` command
+
+**Files:**
+
+- Create: `src/commands/resume.ts`
+- Create: `tests/commands/resume.test.ts`
+- Modify: `src/index.ts` (add case for "resume")
+
+**Step 1: Write the failing test**
+
+Create `tests/commands/resume.test.ts`:
+
+```typescript
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { ProjectIndex } from "../../src/lib/index.ts";
+import { getResumeContext } from "../../src/commands/resume.ts";
+import { join } from "path";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { tmpdir } from "os";
+
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "gx-test-"));
+  indexPath = join(tmpDir, "index.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true });
+});
+
+test("getResumeContext returns context for a git repo", async () => {
+  // Create a real git repo
+  const repoDir = join(tmpDir, "myrepo");
+  await mkdir(repoDir, { recursive: true });
+  let proc = Bun.spawn(["git", "init"], {
+    cwd: repoDir,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+  proc = Bun.spawn(["git", "commit", "--allow-empty", "-m", "initial"], {
+    cwd: repoDir,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+
+  const ctx = await getResumeContext(repoDir);
+  expect(ctx.branch).toBeDefined();
+  expect(typeof ctx.dirtyCount).toBe("number");
+  expect(ctx.lastCommit).toBeDefined();
+});
+
+test("getResumeContext returns null for missing directory", async () => {
+  const ctx = await getResumeContext("/nonexistent/path");
+  expect(ctx).toBeNull();
+});
+
+test("resume fails for unknown project name", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  await idx.save(indexPath);
+  // The resolve would return null for unknown name
+  expect(idx.resolve("unknown")).toBeNull();
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bun test tests/commands/resume.test.ts`
+Expected: FAIL — `getResumeContext` doesn't exist.
+
+**Step 3: Implement the resume command**
+
+Create `src/commands/resume.ts`:
+
+```typescript
+import { ProjectIndex } from "../lib/index.ts";
+import { fuzzyMatch } from "../lib/fuzzy.ts";
+import { relativeTime } from "../lib/time.ts";
+import type { Config } from "../types.ts";
+
+const AUTO_JUMP_THRESHOLD = 0.85;
+
+export interface ResumeContext {
+  branch: string;
+  dirtyCount: number;
+  lastCommit: string;
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  try {
+    const proc = Bun.spawn(["git", ...args], {
+      cwd,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return "";
+    return (await new Response(proc.stdout).text()).trim();
+  } catch {
+    return "";
+  }
+}
+
+export async function getResumeContext(
+  dir: string,
+): Promise<ResumeContext | null> {
+  try {
+    const { statSync } = await import("fs");
+    if (!statSync(dir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const branch = await runGit(dir, ["branch", "--show-current"]);
+  const statusOutput = await runGit(dir, ["status", "--porcelain"]);
+  const dirtyCount = statusOutput
+    ? statusOutput.split("\n").filter((l) => l.length > 0).length
+    : 0;
+  const lastCommit = await runGit(dir, ["log", "-1", "--format=%h %s (%cr)"]);
+
+  return { branch: branch || "HEAD (detached)", dirtyCount, lastCommit };
+}
+
+function resolveName(
+  name: string,
+  idx: ProjectIndex,
+  config: Config,
+): { resolvedName: string; path: string } | null {
+  // Exact match
+  const path = idx.resolve(name);
+  if (path) return { resolvedName: name, path };
+
+  // Fuzzy match
+  const entries = idx.list().map((e) => ({ name: e.name, path: e.path }));
+  const matches = fuzzyMatch(name, entries, config.similarityThreshold);
+
+  if (matches.length === 0) return null;
+
+  const first = matches[0];
+  if (matches.length === 1 && first && first.score >= AUTO_JUMP_THRESHOLD) {
+    console.error(
+      `Fuzzy match: '${name}' -> '${first.name}' (${(first.score * 100).toFixed(0)}%)`,
+    );
+    return { resolvedName: first.name, path: first.path };
+  }
+
+  // Multiple candidates: show list and bail
+  console.error(`No exact match for '${name}'. Did you mean:`);
+  for (const [i, m] of matches.entries()) {
+    console.error(`  ${i + 1}. ${m.name} (${(m.score * 100).toFixed(0)}%)`);
+  }
+  return null;
+}
+
+export async function resume(
+  name: string,
+  indexPath: string,
+  config: Config,
+): Promise<void> {
+  const idx = await ProjectIndex.load(indexPath);
+
+  const resolved = resolveName(name, idx, config);
+  if (!resolved) {
+    console.error(`Project '${name}' not found in index`);
+    process.exit(1);
+  }
+
+  const ctx = await getResumeContext(resolved.path);
+  if (!ctx) {
+    console.error(
+      `Project '${resolved.resolvedName}' directory not found: ${resolved.path}`,
+    );
+    process.exit(1);
+  }
+
+  // Record visit
+  idx.touch(resolved.resolvedName);
+  await idx.save(indexPath);
+
+  // Print context to stderr (so stdout is just the path for shell cd)
+  const dirty =
+    ctx.dirtyCount > 0
+      ? ` — ${ctx.dirtyCount} dirty ${ctx.dirtyCount === 1 ? "file" : "files"}`
+      : "";
+  console.error(`${resolved.resolvedName} (${ctx.branch})${dirty}`);
+  if (ctx.lastCommit) {
+    console.error(`  Last commit: ${ctx.lastCommit}`);
+  }
+
+  // Print path to stdout for shell cd
+  console.log(resolved.path);
+}
+```
+
+**Step 4: Wire into CLI**
+
+In `src/index.ts`, add the import:
+
+```typescript
+import { resume } from "./commands/resume.ts";
+```
+
+Add this case in the switch, before `default`:
+
+```typescript
+    case "resume": {
+      const name = args[1];
+      if (!name) {
+        console.error("Usage: gx resume <name>");
+        process.exit(1);
+      }
+      await resume(name, indexPath, config);
+      break;
+    }
+```
+
+Update the help text to include:
+
+```
+  gx resume <name>       Jump to project with git context
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `bun test`
+Expected: All pass.
+
+**Step 6: Commit**
+
+```bash
+git add src/commands/resume.ts tests/commands/resume.test.ts src/index.ts
+git commit -m "feat(tracking): add gx resume command"
+```
+
+---
+
+### Task 8: Update shell integration
+
+**Files:**
+
+- Modify: `src/commands/shell-init.ts`
+- Test: `tests/commands/shell-init.test.ts` (if exists, update; otherwise spot-check via `bun run dev -- shell-init`)
+
+**Step 1: Update zsh shell function**
+
+In the `zshInit()` function in `src/commands/shell-init.ts`:
+
+1. Add `resume` to the passthrough case alongside `recent`:
+
+Change the passthrough line:
+
+```
+ls|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
+```
+
+to:
+
+```
+ls|recent|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
+```
+
+2. Add a `resume` case before the `*` catch-all that works like `clone` (captures path from stdout, displays stderr context, cd's):
+
+```bash
+        resume)
+            local output
+            output=$("$_GX_BIN" resume "${@:2}" 2>&1 1>&3)
+            local target
+            target=$("$_GX_BIN" resume "${@:2}" 3>&1 1>/dev/null 2>&1)
+            ;;
+```
+
+Actually, a simpler approach — since `resume` prints context to stderr and path to stdout (same pattern as `clone`):
+
+Add `resume` case right after the `clone` case:
+
+```bash
+        resume)
+            local output
+            output=$("$_GX_BIN" resume "${@:2}")
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            fi
+            ;;
+```
+
+This works because `resume` prints the path to stdout (captured by `output`) and context to stderr (which passes through to the terminal).
+
+3. Add `recent` and `resume` to the tab completion `commands` array.
+
+Apply the same three changes to `bashInit()` and `fishInit()`.
+
+**For bash** — same pattern: add `resume` case after `clone`, add `recent` to passthrough, update completion.
+
+**For fish** — add `resume` case in the `switch`, add `recent` to passthrough, update completion:
+
+```fish
+        case resume
+            set -l output ($_GX_BIN resume $argv[2..])
+            if test -n "$output" -a -d "$output"
+                cd "$output"
+            end
+```
+
+**Step 2: Run existing shell-init tests**
+
+Run: `bun test tests/commands/shell-init.test.ts` (if exists)
+Otherwise: `bun run dev -- shell-init zsh` and visually verify `resume` and `recent` appear.
+
+**Step 3: Run all tests**
+
+Run: `bun test`
+Expected: All pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/commands/shell-init.ts
+git commit -m "feat(tracking): add recent and resume to shell integration"
+```
+
+---
+
+### Task 9: Build and verify end-to-end
+
+**Files:** None (verification only)
+
+**Step 1: Type check**
+
+Run: `bun x tsc --noEmit`
+Expected: No errors.
+
+**Step 2: Run full test suite**
+
+Run: `bun test`
+Expected: All pass.
+
+**Step 3: Build binary**
+
+Run: `bun run build`
+Expected: Compiles successfully.
+
+**Step 4: Smoke test**
+
+```bash
+./gx recent
+./gx shell-init zsh | grep -E "recent|resume"
+```
+
+Expected: `recent` shows project list (or empty message), shell-init output contains both `recent` and `resume`.
+
+**Step 5: Commit any fixes, then final commit if needed**
+
+If everything is clean, no commit needed. If fixes were applied, commit them.
+
+---
+
+### Task 10: Update module spec status
+
+**Files:**
+
+- Modify: `plans/modules/09-tracking.aps.md`
+- Modify: `plans/index.aps.md`
+
+**Step 1: Update tracking module to Ready/Complete**
+
+In `plans/modules/09-tracking.aps.md`, update the status table and check the ready checklist items.
+
+In `plans/index.aps.md`, update the Tracking row status from "Draft" to "Complete" and check the v3 success criteria items for `gx recent` and `gx resume`.
+
+**Step 2: Commit**
+
+```bash
+git add plans/modules/09-tracking.aps.md plans/index.aps.md
+git commit -m "docs: update tracking module status to complete"
+```

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -1,12 +1,12 @@
 # gx — Git Project Manager
 
-| Field | Value |
-|-------|-------|
-| Status | In Progress |
-| Owner | @joshuaboys |
-| Created | 2026-02-22 |
-| v1 Completed | 2026-02-23 |
-| v2 Completed | 2026-02-23 |
+| Field        | Value       |
+| ------------ | ----------- |
+| Status       | In Progress |
+| Owner        | @joshuaboys |
+| Created      | 2026-02-22  |
+| v1 Completed | 2026-02-23  |
+| v2 Completed | 2026-02-23  |
 
 ## Problem
 
@@ -31,8 +31,8 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 
 ### v3 — Project Awareness (Draft)
 
-- [ ] `gx recent` lists projects sorted by last visited
-- [ ] `gx resume <name>` jumps to project and prints context (branch, dirty files, last commit)
+- [x] `gx recent` lists projects sorted by last visited
+- [x] `gx resume <name>` jumps to project and prints context (branch, dirty files, last commit)
 - [ ] `gx dash` shows all projects grouped by git status (dirty, ahead, clean, stale)
 - [ ] Dashboard output is colored ANSI with group headers
 - [ ] Parallel git status queries complete within reasonable time for 50+ projects
@@ -59,41 +59,41 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 
 ## Modules
 
-| Module | Purpose | Status | Version | Dependencies |
-|--------|---------|--------|---------|--------------|
-| [URL & Path](./archive/modules/01-url.aps.md) | Parse git URLs and map to filesystem paths | Complete (archived) | v1 | — |
-| [Clone](./archive/modules/02-clone.aps.md) | Clone repos to organized directories | Complete (archived) | v1 | URL |
-| [Index](./archive/modules/03-index.aps.md) | Track projects and resolve names to paths | Complete (archived) | v1 | — |
-| [CLI](./archive/modules/04-cli.aps.md) | Subcommand routing and argument parsing | Complete (archived) | v1 | URL, Clone, Index |
-| [Shell Plugin](./archive/modules/05-shell.aps.md) | Zsh plugin for cd, completion, and shell integration | Complete (archived) | v1 | CLI |
-| [Fuzzy Matching](./archive/modules/06-fuzzy.aps.md) | Suggest closest matches when exact project name not found | Complete (archived) | v2 | Index |
-| [Editor Integration](./archive/modules/07-editor.aps.md) | Open projects in preferred editor | Complete (archived) | v2 | Index, CLI |
-| [Agent Scaffolding](./archive/modules/08-agent.aps.md) | Scaffold AI agent configuration for projects | Complete (archived) | v2 | CLI |
-| [Tracking](./modules/09-tracking.aps.md) | Record project visits and enable recency-based navigation | Draft | v3 | Index |
-| [Dashboard](./modules/10-dashboard.aps.md) | Colored ANSI overview of all projects grouped by git status | Draft | v3 | Index, Tracking |
-| [Hooks](./modules/11-hooks.aps.md) | Per-project onEnter commands with trust/allow safety | Future | v4 | Shell Plugin |
-| [Templates](./modules/12-templates.aps.md) | Create new projects from template repositories | Future | v4 | Clone, Index |
-| [Interactive TUI](./modules/13-tui.aps.md) | Keyboard-navigable interactive terminal dashboard | Future | v4 | Dashboard, Tracking |
-| [Tutorial](./modules/14-tutorial.aps.md) | Interactive walkthrough teaching gx features | Future | v4 | All stable modules |
-| [Distribution & Install UX](./modules/15-distribution.aps.md) | Release binaries, installer, and doctor flow for easy adoption | Draft | v5 | CLI |
-| [Shell Portability](./modules/16-shell-portability.aps.md) | Bash/fish integration and completion parity | Draft | v5 | Shell Plugin, CLI |
-| [Index Reliability & Observability](./modules/17-index-observability.aps.md) | Index diagnostics, stats, and scan telemetry | Draft | v5 | Index, Tracking |
-| [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready | v6 | CLI, APS scaffolding |
+| Module                                                                                    | Purpose                                                                                       | Status              | Version | Dependencies         |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------- | ------- | -------------------- |
+| [URL & Path](./archive/modules/01-url.aps.md)                                             | Parse git URLs and map to filesystem paths                                                    | Complete (archived) | v1      | —                    |
+| [Clone](./archive/modules/02-clone.aps.md)                                                | Clone repos to organized directories                                                          | Complete (archived) | v1      | URL                  |
+| [Index](./archive/modules/03-index.aps.md)                                                | Track projects and resolve names to paths                                                     | Complete (archived) | v1      | —                    |
+| [CLI](./archive/modules/04-cli.aps.md)                                                    | Subcommand routing and argument parsing                                                       | Complete (archived) | v1      | URL, Clone, Index    |
+| [Shell Plugin](./archive/modules/05-shell.aps.md)                                         | Zsh plugin for cd, completion, and shell integration                                          | Complete (archived) | v1      | CLI                  |
+| [Fuzzy Matching](./archive/modules/06-fuzzy.aps.md)                                       | Suggest closest matches when exact project name not found                                     | Complete (archived) | v2      | Index                |
+| [Editor Integration](./archive/modules/07-editor.aps.md)                                  | Open projects in preferred editor                                                             | Complete (archived) | v2      | Index, CLI           |
+| [Agent Scaffolding](./archive/modules/08-agent.aps.md)                                    | Scaffold AI agent configuration for projects                                                  | Complete (archived) | v2      | CLI                  |
+| [Tracking](./modules/09-tracking.aps.md)                                                  | Record project visits and enable recency-based navigation                                     | Complete            | v3      | Index                |
+| [Dashboard](./modules/10-dashboard.aps.md)                                                | Colored ANSI overview of all projects grouped by git status                                   | Draft               | v3      | Index, Tracking      |
+| [Hooks](./modules/11-hooks.aps.md)                                                        | Per-project onEnter commands with trust/allow safety                                          | Future              | v4      | Shell Plugin         |
+| [Templates](./modules/12-templates.aps.md)                                                | Create new projects from template repositories                                                | Future              | v4      | Clone, Index         |
+| [Interactive TUI](./modules/13-tui.aps.md)                                                | Keyboard-navigable interactive terminal dashboard                                             | Future              | v4      | Dashboard, Tracking  |
+| [Tutorial](./modules/14-tutorial.aps.md)                                                  | Interactive walkthrough teaching gx features                                                  | Future              | v4      | All stable modules   |
+| [Distribution & Install UX](./modules/15-distribution.aps.md)                             | Release binaries, installer, and doctor flow for easy adoption                                | Draft               | v5      | CLI                  |
+| [Shell Portability](./modules/16-shell-portability.aps.md)                                | Bash/fish integration and completion parity                                                   | Draft               | v5      | Shell Plugin, CLI    |
+| [Index Reliability & Observability](./modules/17-index-observability.aps.md)              | Index diagnostics, stats, and scan telemetry                                                  | Draft               | v5      | Index, Tracking      |
+| [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready               | v6      | CLI, APS scaffolding |
 
 ## Risks
 
-| Risk | Impact | Mitigation |
-|------|--------|------------|
-| Bun compile binary size | Large binary for simple CLI | Acceptable for v1, benchmark and optimize later |
-| URL edge cases | Malformed URLs cause crashes | Port gclone's validation regex, comprehensive test suite |
-| Index name collisions | Two repos with same basename | Last-write-wins for v1, warn on collision |
-| Fuzzy match false positives | Auto-jump to wrong project on weak match | Require high similarity threshold for auto-jump, confirm otherwise |
-| Editor detection fragility | `$EDITOR` not set or points to unknown binary | Maintain known-editor list, fall back to sensible default |
-| Template staleness | Scaffolded CLAUDE.md becomes outdated as conventions change | Keep templates minimal and project-type-specific, easy to regenerate |
-| Dashboard performance at scale | Git status across 100+ repos could be slow | Bounded concurrency (8 parallel), timeout per repo, cache recent results |
-| Index schema migration | Adding `lastVisited` field to existing entries | Make field optional, null = never visited, no migration step required |
-| Hook security surface | Malicious `.gx.json` could run arbitrary commands | direnv-style trust/allow — hooks never run until user explicitly trusts project |
-| TUI terminal compatibility | Escape sequences differ across terminals | Target xterm-256color, degrade gracefully, always provide non-interactive fallback |
+| Risk                           | Impact                                                      | Mitigation                                                                         |
+| ------------------------------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Bun compile binary size        | Large binary for simple CLI                                 | Acceptable for v1, benchmark and optimize later                                    |
+| URL edge cases                 | Malformed URLs cause crashes                                | Port gclone's validation regex, comprehensive test suite                           |
+| Index name collisions          | Two repos with same basename                                | Last-write-wins for v1, warn on collision                                          |
+| Fuzzy match false positives    | Auto-jump to wrong project on weak match                    | Require high similarity threshold for auto-jump, confirm otherwise                 |
+| Editor detection fragility     | `$EDITOR` not set or points to unknown binary               | Maintain known-editor list, fall back to sensible default                          |
+| Template staleness             | Scaffolded CLAUDE.md becomes outdated as conventions change | Keep templates minimal and project-type-specific, easy to regenerate               |
+| Dashboard performance at scale | Git status across 100+ repos could be slow                  | Bounded concurrency (8 parallel), timeout per repo, cache recent results           |
+| Index schema migration         | Adding `lastVisited` field to existing entries              | Make field optional, null = never visited, no migration step required              |
+| Hook security surface          | Malicious `.gx.json` could run arbitrary commands           | direnv-style trust/allow — hooks never run until user explicitly trusts project    |
+| TUI terminal compatibility     | Escape sequences differ across terminals                    | Target xterm-256color, degrade gracefully, always provide non-interactive fallback |
 
 ## Open Questions
 
@@ -105,7 +105,7 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - [x] Should `gx init` overwrite existing `.claude/CLAUDE.md` or merge? — Refuse without `--force`; no merge
 - [ ] Should `gx open` support opening specific files within a project?
 - [ ] Should `gx recent` show a configurable default count or always show all?
-- [ ] What git commands should `gx resume` run for context? (`git status --short`, `git log -1 --oneline`, `git branch --show-current`)
+- [x] What git commands should `gx resume` run for context? — `git branch --show-current`, `git status --porcelain`, `git log -1 --format='%h %s (%cr)'`
 - [ ] Should `gx dash` fetch remotes before reporting ahead/behind, or use local state only?
 - [ ] What stale threshold default? (30 days proposed)
 - [ ] Should hook trust be per-project or per-file-hash (re-trust on `.gx.json` change)?
@@ -113,11 +113,12 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 
 ## Decisions
 
-- **D-001:** Owner/repo directory structure by default (`owner`), `flat` (repo only) and `host` (host/owner/repo) modes via config — *accepted*
-- **D-002:** github.com as default host for shorthand `user/repo` — *accepted*
-- **D-003:** Binary + multi-shell integration architecture — `gx shell-init` generates eval-able code for zsh, bash, and fish; `plugin/gx.plugin.zsh` is a legacy oh-my-zsh compatibility shim — *accepted*
-- **D-004:** `gx <name>` as default action (jump to project) — *accepted*
-- **D-005:** Dashboard uses local git state only — no remote fetch on `gx dash` (too slow for multi-project scan) — *proposed*
-- **D-006:** `lastVisited` is an optional field on IndexEntry — backward compatible, no migration needed — *proposed*
-- **D-007:** v3 before v4 — tracking and dashboard provide immediate value and inform TUI design — *proposed*
-- **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — *accepted*
+- **D-001:** Owner/repo directory structure by default (`owner`), `flat` (repo only) and `host` (host/owner/repo) modes via config — _accepted_
+- **D-002:** github.com as default host for shorthand `user/repo` — _accepted_
+- **D-003:** Binary + multi-shell integration architecture — `gx shell-init` generates eval-able code for zsh, bash, and fish; `plugin/gx.plugin.zsh` is a legacy oh-my-zsh compatibility shim — _accepted_
+- **D-004:** `gx <name>` as default action (jump to project) — _accepted_
+- **D-005:** Dashboard uses local git state only — no remote fetch on `gx dash` (too slow for multi-project scan) — _proposed_
+- **D-006:** `lastVisited` is an optional field on IndexEntry — backward compatible, no migration needed — _accepted_
+- **D-009:** No separate `gx touch` command — `resolve` updates `lastVisited` as a side effect, eliminating a subprocess spawn per navigation — _accepted_
+- **D-007:** v3 before v4 — tracking and dashboard provide immediate value and inform TUI design — _proposed_
+- **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — _accepted_

--- a/plans/modules/09-tracking.aps.md
+++ b/plans/modules/09-tracking.aps.md
@@ -1,8 +1,8 @@
 # Project Tracking
 
-| ID | Owner | Status |
-|----|-------|--------|
-| TRK | @joshuaboys | Draft |
+| ID  | Owner       | Status   |
+| --- | ----------- | -------- |
+| TRK | @joshuaboys | Complete |
 
 ## Purpose
 
@@ -15,7 +15,6 @@ Track when projects are visited so users can quickly return to recently used pro
 - `gx recent` — list projects sorted by most recently visited
 - `gx recent -n <N>` — limit output to last N projects
 - `gx resume <name>` — jump to project and print context (current branch, dirty file count, last commit summary)
-- Internal `gx touch <name>` subcommand for shell plugin to record visits without resolving
 - Tab completion for `gx recent` and `gx resume`
 
 ## Out of Scope
@@ -33,30 +32,26 @@ Track when projects are visited so users can quickly return to recently used pro
 
 **Exposes:**
 
-- `touch(name: string): Promise<void>` — update `lastVisited` for a project
-- `recent(limit?: number): IndexEntry[]` — return projects sorted by `lastVisited` descending
-- `resume(name: string): ResumeContext` — resolve project path and gather git context
+- `touch(name: string): boolean` — update `lastVisited` for a project (internal method on ProjectIndex)
+- `recent(limit?: number): Array<[string, IndexEntry]>` — return projects sorted by `lastVisited` descending
+- `getResumeContext(dir: string): ResumeContext | null` — gather git context for a project directory
 - `recent` subcommand in CLI
 - `resume` subcommand in CLI
-- `touch` subcommand in CLI (internal, used by shell plugin)
+
+## Design Decision
+
+The original spec included a separate `gx touch` CLI command for the shell plugin to call after each `cd`. During design review, this was eliminated: `resolve` now updates `lastVisited` as a side effect, removing an entire subprocess spawn per navigation.
 
 ## Constraints
 
-- Must not break existing index.json format — `lastVisited` is optional (null for never-visited projects)
+- Must not break existing index.json format — `lastVisited` is optional (absent for never-visited projects)
 - `gx resume` must not fail if the project directory has been deleted — report "project missing" gracefully
 - `gx recent` with no visits yet should fall back to `clonedAt` ordering
-- `gx touch` should be fast (no stdout, minimal I/O) since it runs on every shell navigation
 
 ## Ready Checklist
 
-Change status to **Ready** when:
-
-- [ ] Purpose and scope are clear
-- [ ] Index entry schema extension designed (backward-compatible)
-- [ ] Shell plugin integration for `touch` defined
-- [ ] Dependencies identified
-- [ ] At least one task defined
-
-## Work Items
-
-_None yet -- tasks will be defined when this module reaches Ready status._
+- [x] Purpose and scope are clear
+- [x] Index entry schema extension designed (backward-compatible)
+- [x] Shell plugin integration defined (resolve updates lastVisited as side effect)
+- [x] Dependencies identified
+- [x] At least one task defined

--- a/plans/modules/09-tracking.aps.md
+++ b/plans/modules/09-tracking.aps.md
@@ -48,6 +48,15 @@ The original spec included a separate `gx touch` CLI command for the shell plugi
 - `gx resume` must not fail if the project directory has been deleted — report "project missing" gracefully
 - `gx recent` with no visits yet should fall back to `clonedAt` ordering
 
+## Work Items
+
+- [x] TRK-1: Add `lastVisited` field and `touch()` method to ProjectIndex
+- [x] TRK-2: Update `resolve` to call `touch()` on match
+- [x] TRK-3: Implement `gx recent` command
+- [x] TRK-4: Implement `gx resume` command with git context
+- [x] TRK-5: Add shell wrapper integration for `resume`
+- [x] TRK-6: Add tab completion for `recent` and `resume`
+
 ## Ready Checklist
 
 - [x] Purpose and scope are clear

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -8,7 +8,7 @@ import type { Config } from "../types.ts";
 export async function cloneRepo(
   input: string,
   config: Config,
-  indexPath: string
+  indexPath: string,
 ): Promise<string> {
   const parsed = parseUrl(input, config.defaultHost);
   const targetDir = toPath(parsed, config);
@@ -25,7 +25,11 @@ export async function cloneRepo(
       return targetDir;
     }
   } catch (err: unknown) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code !== "ENOENT") {
+    if (
+      err instanceof Error &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code !== "ENOENT"
+    ) {
       throw err;
     }
     // ENOENT = doesn't exist, continue with clone
@@ -51,10 +55,12 @@ export async function cloneRepo(
 
   // Update index
   const idx = await ProjectIndex.load(indexPath);
+  const now = new Date().toISOString();
   idx.add(parsed.repo, {
     path: targetDir,
     url: cloneUrl,
-    clonedAt: new Date().toISOString(),
+    clonedAt: now,
+    lastVisited: now,
   });
   await idx.save(indexPath);
 

--- a/src/commands/recent.ts
+++ b/src/commands/recent.ts
@@ -1,0 +1,19 @@
+import { ProjectIndex } from "../lib/index.ts";
+import { relativeTime } from "../lib/time.ts";
+
+export async function recent(indexPath: string, limit?: number): Promise<void> {
+  const idx = await ProjectIndex.load(indexPath);
+  const entries = idx.recent(limit);
+
+  if (entries.length === 0) {
+    console.error("No projects indexed. Clone a repo or run 'gx rebuild'.");
+    return;
+  }
+
+  const maxName = Math.max(...entries.map(([name]) => name.length));
+  for (const [name, entry] of entries) {
+    const time = relativeTime(entry.lastVisited || entry.clonedAt);
+    const timeStr = time ? `  ${time}` : "";
+    console.log(`${name.padEnd(maxName)}  ${entry.path}${timeStr}`);
+  }
+}

--- a/src/commands/resolve.ts
+++ b/src/commands/resolve.ts
@@ -1,8 +1,6 @@
 import { ProjectIndex } from "../lib/index.ts";
-import { fuzzyMatch } from "../lib/fuzzy.ts";
+import { fuzzyMatch, AUTO_JUMP_THRESHOLD } from "../lib/fuzzy.ts";
 import type { Config } from "../types.ts";
-
-const AUTO_JUMP_THRESHOLD = 0.85;
 
 export async function resolve(
   name: string,

--- a/src/commands/resolve.ts
+++ b/src/commands/resolve.ts
@@ -20,6 +20,8 @@ export async function resolve(
   // Try exact match first
   const path = idx.resolve(name);
   if (path) {
+    idx.touch(name);
+    await idx.save(indexPath);
     console.log(path);
     return;
   }
@@ -35,7 +37,11 @@ export async function resolve(
 
   const first = matches[0];
   if (matches.length === 1 && first && first.score >= AUTO_JUMP_THRESHOLD) {
-    console.error(`Fuzzy match: '${name}' -> '${first.name}' (${(first.score * 100).toFixed(0)}%)`);
+    console.error(
+      `Fuzzy match: '${name}' -> '${first.name}' (${(first.score * 100).toFixed(0)}%)`,
+    );
+    idx.touch(first.name);
+    await idx.save(indexPath);
     console.log(first.path);
     return;
   }

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -1,8 +1,7 @@
+import { stat } from "fs/promises";
 import { ProjectIndex } from "../lib/index.ts";
-import { fuzzyMatch } from "../lib/fuzzy.ts";
+import { fuzzyMatch, AUTO_JUMP_THRESHOLD } from "../lib/fuzzy.ts";
 import type { Config } from "../types.ts";
-
-const AUTO_JUMP_THRESHOLD = 0.85;
 
 export interface ResumeContext {
   branch: string;
@@ -29,8 +28,8 @@ export async function getResumeContext(
   dir: string,
 ): Promise<ResumeContext | null> {
   try {
-    const { statSync } = await import("fs");
-    if (!statSync(dir).isDirectory()) return null;
+    const s = await stat(dir);
+    if (!s.isDirectory()) return null;
   } catch {
     return null;
   }

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -1,0 +1,110 @@
+import { ProjectIndex } from "../lib/index.ts";
+import { fuzzyMatch } from "../lib/fuzzy.ts";
+import type { Config } from "../types.ts";
+
+const AUTO_JUMP_THRESHOLD = 0.85;
+
+export interface ResumeContext {
+  branch: string;
+  dirtyCount: number;
+  lastCommit: string;
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  try {
+    const proc = Bun.spawn(["git", ...args], {
+      cwd,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return "";
+    return (await new Response(proc.stdout).text()).trim();
+  } catch {
+    return "";
+  }
+}
+
+export async function getResumeContext(
+  dir: string,
+): Promise<ResumeContext | null> {
+  try {
+    const { statSync } = await import("fs");
+    if (!statSync(dir).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  const branch = await runGit(dir, ["branch", "--show-current"]);
+  const statusOutput = await runGit(dir, ["status", "--porcelain"]);
+  const dirtyCount = statusOutput
+    ? statusOutput.split("\n").filter((l) => l.length > 0).length
+    : 0;
+  const lastCommit = await runGit(dir, ["log", "-1", "--format=%h %s (%cr)"]);
+
+  return { branch: branch || "HEAD (detached)", dirtyCount, lastCommit };
+}
+
+function resolveName(
+  name: string,
+  idx: ProjectIndex,
+  config: Config,
+): { resolvedName: string; path: string } | null {
+  const path = idx.resolve(name);
+  if (path) return { resolvedName: name, path };
+
+  const entries = idx.list().map((e) => ({ name: e.name, path: e.path }));
+  const matches = fuzzyMatch(name, entries, config.similarityThreshold);
+
+  if (matches.length === 0) return null;
+
+  const first = matches[0];
+  if (matches.length === 1 && first && first.score >= AUTO_JUMP_THRESHOLD) {
+    console.error(
+      `Fuzzy match: '${name}' -> '${first.name}' (${(first.score * 100).toFixed(0)}%)`,
+    );
+    return { resolvedName: first.name, path: first.path };
+  }
+
+  console.error(`No exact match for '${name}'. Did you mean:`);
+  for (const [i, m] of matches.entries()) {
+    console.error(`  ${i + 1}. ${m.name} (${(m.score * 100).toFixed(0)}%)`);
+  }
+  return null;
+}
+
+export async function resume(
+  name: string,
+  indexPath: string,
+  config: Config,
+): Promise<void> {
+  const idx = await ProjectIndex.load(indexPath);
+
+  const resolved = resolveName(name, idx, config);
+  if (!resolved) {
+    console.error(`Project '${name}' not found in index`);
+    process.exit(1);
+  }
+
+  const ctx = await getResumeContext(resolved.path);
+  if (!ctx) {
+    console.error(
+      `Project '${resolved.resolvedName}' directory not found: ${resolved.path}`,
+    );
+    process.exit(1);
+  }
+
+  idx.touch(resolved.resolvedName);
+  await idx.save(indexPath);
+
+  const dirty =
+    ctx.dirtyCount > 0
+      ? ` — ${ctx.dirtyCount} dirty ${ctx.dirtyCount === 1 ? "file" : "files"}`
+      : "";
+  console.error(`${resolved.resolvedName} (${ctx.branch})${dirty}`);
+  if (ctx.lastCommit) {
+    console.error(`  Last commit: ${ctx.lastCommit}`);
+  }
+
+  console.log(resolved.path);
+}

--- a/src/commands/shell-init.ts
+++ b/src/commands/shell-init.ts
@@ -49,7 +49,14 @@ gx() {
                 cd "$output"
             fi
             ;;
-        ls|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
+        resume)
+            local output
+            output=$("$_GX_BIN" resume "\${@:2}")
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            fi
+            ;;
+        ls|recent|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
             "$_GX_BIN" "$@"
             ;;
         resolve)
@@ -82,14 +89,14 @@ gx() {
 # Tab completion
 _gx() {
     local -a commands projects
-    commands=(clone ls rebuild config resolve open init shell-init --help --version -h -v)
+    commands=(clone ls recent resume rebuild config resolve open init shell-init --help --version -h -v)
 
     if (( CURRENT == 2 )); then
         projects=($("$_GX_BIN" resolve --list 2>/dev/null))
         compadd "\${commands[@]}" "\${projects[@]}"
     elif (( CURRENT == 3 )); then
         case "\${words[2]}" in
-            clone|ls|rebuild|config|resolve|open|init|shell-init|--help|--version|-h|-v)
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|shell-init|--help|--version|-h|-v)
                 if [[ "\${words[2]}" == "config" ]]; then
                     compadd set
                 fi
@@ -121,7 +128,14 @@ gx() {
                 cd "$output"
             fi
             ;;
-        ls|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
+        resume)
+            local output
+            output=$("$_GX_BIN" resume "\${@:2}")
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            fi
+            ;;
+        ls|recent|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
             "$_GX_BIN" "$@"
             ;;
         resolve)
@@ -157,13 +171,13 @@ _gx_completions() {
     local prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
     if [ "\$COMP_CWORD" -eq 1 ]; then
-        local commands="clone ls rebuild config resolve open init shell-init --help --version -h -v"
+        local commands="clone ls recent resume rebuild config resolve open init shell-init --help --version -h -v"
         local projects
         projects=$("$_GX_BIN" resolve --list 2>/dev/null)
         COMPREPLY=($(compgen -W "$commands $projects" -- "$cur"))
     elif [ "\$COMP_CWORD" -eq 2 ]; then
         case "\${COMP_WORDS[1]}" in
-            clone|ls|rebuild|config|resolve|open|init|shell-init|--help|--version|-h|-v)
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|shell-init|--help|--version|-h|-v)
                 if [ "\${COMP_WORDS[1]}" = "config" ]; then
                     COMPREPLY=($(compgen -W "set" -- "$cur"))
                 fi
@@ -193,7 +207,12 @@ function gx
             if test -n "$output" -a -d "$output"
                 cd "$output"
             end
-        case ls rebuild config open init shell-init --help -h --version -v resolve
+        case resume
+            set -l output ($_GX_BIN resume $argv[2..])
+            if test -n "$output" -a -d "$output"
+                cd "$output"
+            end
+        case ls recent rebuild config open init shell-init --help -h --version -v resolve
             $_GX_BIN $argv
         case ''
             $_GX_BIN --help
@@ -217,11 +236,11 @@ end
 
 # Tab completion
 complete -c gx -f
-complete -c gx -n "__fish_use_subcommand" -a "clone ls rebuild config resolve open init shell-init --help --version -h -v"
+complete -c gx -n "__fish_use_subcommand" -a "clone ls recent resume rebuild config resolve open init shell-init --help --version -h -v"
 complete -c gx -n "__fish_use_subcommand" -a "($_GX_BIN resolve --list 2>/dev/null)"
 complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
 complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"
-complete -c gx -n "not __fish_seen_subcommand_from clone ls rebuild config resolve open init shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt"`;
+complete -c gx -n "not __fish_seen_subcommand_from clone ls recent resume rebuild config resolve open init shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt"`;
 }
 
 export function shellInit(shellArg?: string): void {

--- a/src/commands/shell-init.ts
+++ b/src/commands/shell-init.ts
@@ -52,8 +52,14 @@ gx() {
         resume)
             local output
             output=$("$_GX_BIN" resume "\${@:2}")
+            local status=$?
+            if [ "$status" -ne 0 ]; then
+                return "$status"
+            fi
             if [ -n "$output" ] && [ -d "$output" ]; then
                 cd "$output"
+            else
+                return 1
             fi
             ;;
         ls|recent|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
@@ -129,10 +135,16 @@ gx() {
             fi
             ;;
         resume)
-            local output
+            local output status
             output=$("$_GX_BIN" resume "\${@:2}")
+            status=$?
+            if [ "$status" -ne 0 ]; then
+                return "$status"
+            fi
             if [ -n "$output" ] && [ -d "$output" ]; then
                 cd "$output"
+            else
+                return 1
             fi
             ;;
         ls|recent|rebuild|config|open|init|shell-init|--help|-h|--version|-v)
@@ -209,8 +221,14 @@ function gx
             end
         case resume
             set -l output ($_GX_BIN resume $argv[2..])
+            set -l cmd_status $status
+            if test $cmd_status -ne 0
+                return $cmd_status
+            end
             if test -n "$output" -a -d "$output"
                 cd "$output"
+            else
+                return 1
             end
         case ls recent rebuild config open init shell-init --help -h --version -v resolve
             $_GX_BIN $argv

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { initAgent } from "./commands/init.ts";
 import { shellInit } from "./commands/shell-init.ts";
 import { indexRepos } from "./commands/index-repos.ts";
 import { recent } from "./commands/recent.ts";
+import { resume } from "./commands/resume.ts";
 import pkg from "../package.json";
 
 const VERSION = pkg.version;
@@ -38,6 +39,7 @@ Usage:
   gx rebuild               Rescan and rebuild index
   gx recent              List recently visited projects
   gx recent -n <N>       Show last N projects
+  gx resume <name>       Jump to project with git context
   gx config                Show config
   gx config set <key> <v>  Set config value
   gx init                  Scaffold .claude/ agent config
@@ -148,6 +150,15 @@ Options:
         }
       }
       await recent(indexPath, limit);
+      break;
+    }
+    case "resume": {
+      const name = args[1];
+      if (!name) {
+        console.error("Usage: gx resume <name>");
+        process.exit(1);
+      }
+      await resume(name, indexPath, config);
       break;
     }
     default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,8 +141,12 @@ Options:
     case "recent": {
       const nFlag = args.indexOf("-n");
       let limit: number | undefined;
-      const nValue = nFlag >= 0 ? args[nFlag + 1] : undefined;
-      if (nValue) {
+      if (nFlag >= 0) {
+        const nValue = args[nFlag + 1];
+        if (!nValue || nValue.startsWith("-")) {
+          console.error("Usage: gx recent [-n <count>]");
+          process.exit(1);
+        }
         limit = parseInt(nValue, 10);
         if (isNaN(limit) || limit < 1) {
           console.error("Usage: gx recent [-n <count>]");

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { openProject } from "./commands/open.ts";
 import { initAgent } from "./commands/init.ts";
 import { shellInit } from "./commands/shell-init.ts";
 import { indexRepos } from "./commands/index-repos.ts";
+import { recent } from "./commands/recent.ts";
 import pkg from "../package.json";
 
 const VERSION = pkg.version;
@@ -35,6 +36,8 @@ Usage:
   gx index                 Index new repos (additive scan)
   gx index <path>...       Add specific repo(s) to index
   gx rebuild               Rescan and rebuild index
+  gx recent              List recently visited projects
+  gx recent -n <N>       Show last N projects
   gx config                Show config
   gx config set <key> <v>  Set config value
   gx init                  Scaffold .claude/ agent config
@@ -133,6 +136,20 @@ Options:
         process.exit(1);
       }
       break;
+    case "recent": {
+      const nFlag = args.indexOf("-n");
+      let limit: number | undefined;
+      const nValue = nFlag >= 0 ? args[nFlag + 1] : undefined;
+      if (nValue) {
+        limit = parseInt(nValue, 10);
+        if (isNaN(limit) || limit < 1) {
+          console.error("Usage: gx recent [-n <count>]");
+          process.exit(1);
+        }
+      }
+      await recent(indexPath, limit);
+      break;
+    }
     default:
       // Default: treat as project name to resolve
       await resolve(command, indexPath, config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,9 @@ Usage:
   gx index                 Index new repos (additive scan)
   gx index <path>...       Add specific repo(s) to index
   gx rebuild               Rescan and rebuild index
-  gx recent              List recently visited projects
-  gx recent -n <N>       Show last N projects
-  gx resume <name>       Jump to project with git context
+  gx recent               List recently visited projects
+  gx recent -n <N>        Show last N projects
+  gx resume <name>        Jump to project with git context
   gx config                Show config
   gx config set <key> <v>  Set config value
   gx init                  Scaffold .claude/ agent config

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -1,3 +1,5 @@
+export const AUTO_JUMP_THRESHOLD = 0.85;
+
 export interface FuzzyResult {
   name: string;
   score: number;
@@ -51,7 +53,9 @@ function jaro(a: string, b: string): number {
   }
 
   return (
-    (matches / aLen + matches / bLen + (matches - transpositions / 2) / matches) /
+    (matches / aLen +
+      matches / bLen +
+      (matches - transpositions / 2) / matches) /
     3
   );
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -69,6 +69,22 @@ export class ProjectIndex {
     return this.data.projects[name]?.path ?? null;
   }
 
+  touch(name: string): boolean {
+    const entry = this.data.projects[name];
+    if (!entry) return false;
+    entry.lastVisited = new Date().toISOString();
+    return true;
+  }
+
+  recent(limit?: number): Array<[string, IndexEntry]> {
+    const entries = Object.entries(this.data.projects).sort((a, b) => {
+      const timeA = a[1].lastVisited || a[1].clonedAt || "";
+      const timeB = b[1].lastVisited || b[1].clonedAt || "";
+      return timeB.localeCompare(timeA);
+    });
+    return limit ? entries.slice(0, limit) : entries;
+  }
+
   list(): Array<{ name: string } & IndexEntry> {
     return Object.entries(this.data.projects)
       .map(([name, entry]) => ({ name, ...entry }))

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,17 @@
+export function relativeTime(iso: string): string {
+  if (!iso) return "";
+  const diff = Date.now() - new Date(iso).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60)
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 14) return `${days} ${days === 1 ? "day" : "days"} ago`;
+  const weeks = Math.floor(days / 7);
+  if (days < 60) return `${weeks} ${weeks === 1 ? "week" : "weeks"} ago`;
+  const months = Math.floor(days / 30);
+  return `${months} ${months === 1 ? "month" : "months"} ago`;
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,6 +1,9 @@
 export function relativeTime(iso: string): string {
   if (!iso) return "";
-  const diff = Date.now() - new Date(iso).getTime();
+  const time = new Date(iso).getTime();
+  if (Number.isNaN(time)) return "";
+  const diff = Date.now() - time;
+  if (diff < 0) return "";
   const seconds = Math.floor(diff / 1000);
   if (seconds < 60) return "just now";
   const minutes = Math.floor(seconds / 60);

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface IndexEntry {
   path: string;
   url: string;
   clonedAt: string;
+  lastVisited?: string;
 }
 
 export interface Index {

--- a/tests/commands/recent.test.ts
+++ b/tests/commands/recent.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { ProjectIndex } from "../../src/lib/index.ts";
+import { join } from "path";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "gx-test-"));
+  indexPath = join(tmpDir, "index.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true });
+});
+
+test("recent lists projects sorted by lastVisited", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("old", {
+    path: "/tmp/old",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+    lastVisited: "2026-01-01T00:00:00Z",
+  });
+  idx.add("new", {
+    path: "/tmp/new",
+    url: "",
+    clonedAt: "2026-01-02T00:00:00Z",
+    lastVisited: "2026-03-01T00:00:00Z",
+  });
+  await idx.save(indexPath);
+
+  const result = idx.recent();
+  expect(result[0]![0]).toBe("new");
+  expect(result[1]![0]).toBe("old");
+});
+
+test("recent with empty index produces no output", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  const result = idx.recent();
+  expect(result).toHaveLength(0);
+});

--- a/tests/commands/resolve.test.ts
+++ b/tests/commands/resolve.test.ts
@@ -23,7 +23,7 @@ afterEach(async () => {
   await rm(tmpDir, { recursive: true });
 });
 
-test("resolve updates lastVisited on exact match", async () => {
+test("touch updates lastVisited on exact match", async () => {
   const idx = await ProjectIndex.load(indexPath);
   idx.add("gx", {
     path: "/tmp/gx",

--- a/tests/commands/resolve.test.ts
+++ b/tests/commands/resolve.test.ts
@@ -23,6 +23,25 @@ afterEach(async () => {
   await rm(tmpDir, { recursive: true });
 });
 
+test("resolve updates lastVisited on exact match", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("gx", {
+    path: "/tmp/gx",
+    url: "https://github.com/joshuaboys/gx",
+    clonedAt: "2026-01-01T00:00:00Z",
+  });
+  await idx.save(indexPath);
+
+  const idx2 = await ProjectIndex.load(indexPath);
+  const found = idx2.touch("gx");
+  expect(found).toBe(true);
+  await idx2.save(indexPath);
+
+  const idx3 = await ProjectIndex.load(indexPath);
+  const entry = idx3.list().find((e) => e.name === "gx");
+  expect(entry!.lastVisited).toBeDefined();
+});
+
 describe("resolve", () => {
   test("--list mode prints all names joined by newlines", async () => {
     const logSpy = spyOn(console, "log").mockImplementation(() => {});
@@ -39,7 +58,9 @@ describe("resolve", () => {
   });
 
   test("no match exits with code 1", async () => {
-    const mockExit = spyOn(process, "exit").mockImplementation(() => { throw new Error("exit"); });
+    const mockExit = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
     try {
       await resolve("nonexistent", indexPath, DEFAULT_CONFIG);
     } catch {}

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -25,19 +25,35 @@ test("getResumeContext returns context for a git repo", async () => {
     stdout: "ignore",
     stderr: "ignore",
   });
-  await proc.exited;
-  proc = Bun.spawn(["git", "commit", "--allow-empty", "-m", "initial"], {
-    cwd: repoDir,
-    stdout: "ignore",
-    stderr: "ignore",
-  });
-  await proc.exited;
+  const initExitCode = await proc.exited;
+  expect(initExitCode).toBe(0);
+  proc = Bun.spawn(
+    [
+      "git",
+      "-c",
+      "user.name=Test User",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "initial",
+    ],
+    {
+      cwd: repoDir,
+      stdout: "ignore",
+      stderr: "ignore",
+    },
+  );
+  const commitExitCode = await proc.exited;
+  expect(commitExitCode).toBe(0);
 
   const ctx = await getResumeContext(repoDir);
   expect(ctx).not.toBeNull();
   expect(ctx!.branch).toBeDefined();
   expect(typeof ctx!.dirtyCount).toBe("number");
-  expect(ctx!.lastCommit).toBeDefined();
+  expect(typeof ctx!.lastCommit).toBe("string");
+  expect(ctx!.lastCommit).not.toBe("");
 });
 
 test("getResumeContext returns null for missing directory", async () => {

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, beforeEach, afterEach } from "bun:test";
+import { ProjectIndex } from "../../src/lib/index.ts";
+import { getResumeContext } from "../../src/commands/resume.ts";
+import { join } from "path";
+import { mkdtemp, rm, mkdir } from "fs/promises";
+import { tmpdir } from "os";
+
+let tmpDir: string;
+let indexPath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "gx-test-"));
+  indexPath = join(tmpDir, "index.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true });
+});
+
+test("getResumeContext returns context for a git repo", async () => {
+  const repoDir = join(tmpDir, "myrepo");
+  await mkdir(repoDir, { recursive: true });
+  let proc = Bun.spawn(["git", "init"], {
+    cwd: repoDir,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+  proc = Bun.spawn(["git", "commit", "--allow-empty", "-m", "initial"], {
+    cwd: repoDir,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+
+  const ctx = await getResumeContext(repoDir);
+  expect(ctx).not.toBeNull();
+  expect(ctx!.branch).toBeDefined();
+  expect(typeof ctx!.dirtyCount).toBe("number");
+  expect(ctx!.lastCommit).toBeDefined();
+});
+
+test("getResumeContext returns null for missing directory", async () => {
+  const ctx = await getResumeContext("/nonexistent/path");
+  expect(ctx).toBeNull();
+});
+
+test("resume fails for unknown project name", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  await idx.save(indexPath);
+  expect(idx.resolve("unknown")).toBeNull();
+});

--- a/tests/lib/index.test.ts
+++ b/tests/lib/index.test.ts
@@ -266,3 +266,91 @@ test("scopedRebuild from agent scope only affects agent entries", async () => {
   // Agent entry re-discovered
   expect(idx.resolve("agentrepo")).toBe(join(agentDir, "org", "agentrepo"));
 });
+
+test("touch updates lastVisited on existing entry", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("gx", {
+    path: "/tmp/gx",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+  });
+  const before = new Date().toISOString();
+  const found = idx.touch("gx");
+  const after = new Date().toISOString();
+  expect(found).toBe(true);
+  const entry = idx.list().find((e) => e.name === "gx");
+  expect(entry!.lastVisited).toBeDefined();
+  expect(entry!.lastVisited! >= before).toBe(true);
+  expect(entry!.lastVisited! <= after).toBe(true);
+});
+
+test("touch returns false for unknown project", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  expect(idx.touch("nope")).toBe(false);
+});
+
+test("recent returns entries sorted by lastVisited descending", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("old", {
+    path: "/tmp/old",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+    lastVisited: "2026-01-01T00:00:00Z",
+  });
+  idx.add("new", {
+    path: "/tmp/new",
+    url: "",
+    clonedAt: "2026-01-02T00:00:00Z",
+    lastVisited: "2026-03-01T00:00:00Z",
+  });
+  idx.add("mid", {
+    path: "/tmp/mid",
+    url: "",
+    clonedAt: "2026-01-03T00:00:00Z",
+    lastVisited: "2026-02-01T00:00:00Z",
+  });
+  const result = idx.recent();
+  expect(result.map(([name]) => name)).toEqual(["new", "mid", "old"]);
+});
+
+test("recent falls back to clonedAt when lastVisited is absent", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("visited", {
+    path: "/tmp/visited",
+    url: "",
+    clonedAt: "2026-01-01T00:00:00Z",
+    lastVisited: "2026-02-01T00:00:00Z",
+  });
+  idx.add("unvisited", {
+    path: "/tmp/unvisited",
+    url: "",
+    clonedAt: "2026-03-01T00:00:00Z",
+  });
+  const result = idx.recent();
+  expect(result.map(([name]) => name)).toEqual(["unvisited", "visited"]);
+});
+
+test("recent respects limit parameter", async () => {
+  const idx = await ProjectIndex.load(indexPath);
+  idx.add("a", {
+    path: "/tmp/a",
+    url: "",
+    clonedAt: "",
+    lastVisited: "2026-03-03T00:00:00Z",
+  });
+  idx.add("b", {
+    path: "/tmp/b",
+    url: "",
+    clonedAt: "",
+    lastVisited: "2026-03-02T00:00:00Z",
+  });
+  idx.add("c", {
+    path: "/tmp/c",
+    url: "",
+    clonedAt: "",
+    lastVisited: "2026-03-01T00:00:00Z",
+  });
+  const result = idx.recent(2);
+  expect(result).toHaveLength(2);
+  expect(result.map(([name]) => name)).toEqual(["a", "b"]);
+});

--- a/tests/lib/time.test.ts
+++ b/tests/lib/time.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "bun:test";
+import { relativeTime } from "../../src/lib/time.ts";
+
+test("returns 'just now' for timestamps within 60 seconds", () => {
+  const now = new Date();
+  expect(relativeTime(now.toISOString())).toBe("just now");
+});
+
+test("returns minutes ago", () => {
+  const t = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("5 minutes ago");
+});
+
+test("returns '1 minute ago' for singular", () => {
+  const t = new Date(Date.now() - 90 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("1 minute ago");
+});
+
+test("returns hours ago", () => {
+  const t = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("3 hours ago");
+});
+
+test("returns days ago", () => {
+  const t = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("2 days ago");
+});
+
+test("returns weeks ago", () => {
+  const t = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("2 weeks ago");
+});
+
+test("returns months ago", () => {
+  const t = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+  expect(relativeTime(t)).toBe("2 months ago");
+});
+
+test("returns empty string for empty input", () => {
+  expect(relativeTime("")).toBe("");
+});


### PR DESCRIPTION
## Summary

- Add `lastVisited` optional field to `IndexEntry` for recording project visit timestamps
- `resolve` updates `lastVisited` as a side effect (no separate `touch` command needed)
- `clone` sets `lastVisited` at creation time
- New `gx recent [-n N]` command lists projects by most recently visited with relative timestamps
- New `gx resume <name>` command jumps to project and prints git context (branch, dirty files, last commit)
- Shell integration updated for all 3 shells (zsh, bash, fish) with `resume` cd-wrapper and tab completion

## Test plan

- [x] 203 tests pass (19 new tests covering touch, recent, relativeTime, resume, resolve tracking)
- [x] `bun x tsc --noEmit` clean
- [x] `bun run build` compiles successfully
- [x] Smoke tested `gx recent` and `gx shell-init` output
- [ ] Manual test: `gx <name>` jump updates lastVisited in index.json
- [ ] Manual test: `gx resume <name>` shows branch/dirty/commit context and cd's

🤖 Generated with [Claude Code](https://claude.com/claude-code)