### PR TITLE
docs(plans): add fork & sync module (FRK-19)

### DIFF
--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -1,12 +1,12 @@
 # gx — Git Project Manager
 
-| Field | Value |
-|-------|-------|
-| Status | In Progress |
-| Owner | @joshuaboys |
-| Created | 2026-02-22 |
-| v1 Completed | 2026-02-23 |
-| v2 Completed | 2026-02-23 |
+| Field        | Value       |
+| ------------ | ----------- |
+| Status       | In Progress |
+| Owner        | @joshuaboys |
+| Created      | 2026-02-22  |
+| v1 Completed | 2026-02-23  |
+| v2 Completed | 2026-02-23  |
 
 ## Problem
 
@@ -39,6 +39,9 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 
 ### v4 — Ecosystem (Future)
 
+- [ ] `gx fork <repo>` forks on GitHub, clones locally, sets upstream remote, and indexes
+- [ ] `gx sync` fetches upstream and integrates changes (fast-forward, rebase, or merge)
+- [ ] `gx sync` handles diverged forks safely — never silently discards commits
 - [ ] `.gx.json` hooks run on project entry with trust/allow safety
 - [ ] `gx new <name> --template <tpl>` creates projects from template repos
 - [ ] `gx tui` provides interactive terminal UI for project navigation
@@ -59,41 +62,44 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 
 ## Modules
 
-| Module | Purpose | Status | Version | Dependencies |
-|--------|---------|--------|---------|--------------|
-| [URL & Path](./archive/modules/01-url.aps.md) | Parse git URLs and map to filesystem paths | Complete (archived) | v1 | — |
-| [Clone](./archive/modules/02-clone.aps.md) | Clone repos to organized directories | Complete (archived) | v1 | URL |
-| [Index](./archive/modules/03-index.aps.md) | Track projects and resolve names to paths | Complete (archived) | v1 | — |
-| [CLI](./archive/modules/04-cli.aps.md) | Subcommand routing and argument parsing | Complete (archived) | v1 | URL, Clone, Index |
-| [Shell Plugin](./archive/modules/05-shell.aps.md) | Zsh plugin for cd, completion, and shell integration | Complete (archived) | v1 | CLI |
-| [Fuzzy Matching](./archive/modules/06-fuzzy.aps.md) | Suggest closest matches when exact project name not found | Complete (archived) | v2 | Index |
-| [Editor Integration](./archive/modules/07-editor.aps.md) | Open projects in preferred editor | Complete (archived) | v2 | Index, CLI |
-| [Agent Scaffolding](./archive/modules/08-agent.aps.md) | Scaffold AI agent configuration for projects | Complete (archived) | v2 | CLI |
-| [Tracking](./modules/09-tracking.aps.md) | Record project visits and enable recency-based navigation | Draft | v3 | Index |
-| [Dashboard](./modules/10-dashboard.aps.md) | Colored ANSI overview of all projects grouped by git status | Draft | v3 | Index, Tracking |
-| [Hooks](./modules/11-hooks.aps.md) | Per-project onEnter commands with trust/allow safety | Future | v4 | Shell Plugin |
-| [Templates](./modules/12-templates.aps.md) | Create new projects from template repositories | Future | v4 | Clone, Index |
-| [Interactive TUI](./modules/13-tui.aps.md) | Keyboard-navigable interactive terminal dashboard | Future | v4 | Dashboard, Tracking |
-| [Tutorial](./modules/14-tutorial.aps.md) | Interactive walkthrough teaching gx features | Future | v4 | All stable modules |
-| [Distribution & Install UX](./modules/15-distribution.aps.md) | Release binaries, installer, and doctor flow for easy adoption | Draft | v5 | CLI |
-| [Shell Portability](./modules/16-shell-portability.aps.md) | Bash/fish integration and completion parity | Draft | v5 | Shell Plugin, CLI |
-| [Index Reliability & Observability](./modules/17-index-observability.aps.md) | Index diagnostics, stats, and scan telemetry | Draft | v5 | Index, Tracking |
-| [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready | v6 | CLI, APS scaffolding |
+| Module                                                                                    | Purpose                                                                                       | Status              | Version | Dependencies             |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------------- | ------- | ------------------------ |
+| [URL & Path](./archive/modules/01-url.aps.md)                                             | Parse git URLs and map to filesystem paths                                                    | Complete (archived) | v1      | —                        |
+| [Clone](./archive/modules/02-clone.aps.md)                                                | Clone repos to organized directories                                                          | Complete (archived) | v1      | URL                      |
+| [Index](./archive/modules/03-index.aps.md)                                                | Track projects and resolve names to paths                                                     | Complete (archived) | v1      | —                        |
+| [CLI](./archive/modules/04-cli.aps.md)                                                    | Subcommand routing and argument parsing                                                       | Complete (archived) | v1      | URL, Clone, Index        |
+| [Shell Plugin](./archive/modules/05-shell.aps.md)                                         | Zsh plugin for cd, completion, and shell integration                                          | Complete (archived) | v1      | CLI                      |
+| [Fuzzy Matching](./archive/modules/06-fuzzy.aps.md)                                       | Suggest closest matches when exact project name not found                                     | Complete (archived) | v2      | Index                    |
+| [Editor Integration](./archive/modules/07-editor.aps.md)                                  | Open projects in preferred editor                                                             | Complete (archived) | v2      | Index, CLI               |
+| [Agent Scaffolding](./archive/modules/08-agent.aps.md)                                    | Scaffold AI agent configuration for projects                                                  | Complete (archived) | v2      | CLI                      |
+| [Tracking](./modules/09-tracking.aps.md)                                                  | Record project visits and enable recency-based navigation                                     | Draft               | v3      | Index                    |
+| [Dashboard](./modules/10-dashboard.aps.md)                                                | Colored ANSI overview of all projects grouped by git status                                   | Draft               | v3      | Index, Tracking          |
+| [Hooks](./modules/11-hooks.aps.md)                                                        | Per-project onEnter commands with trust/allow safety                                          | Future              | v4      | Shell Plugin             |
+| [Templates](./modules/12-templates.aps.md)                                                | Create new projects from template repositories                                                | Future              | v4      | Clone, Index             |
+| [Interactive TUI](./modules/13-tui.aps.md)                                                | Keyboard-navigable interactive terminal dashboard                                             | Future              | v4      | Dashboard, Tracking      |
+| [Tutorial](./modules/14-tutorial.aps.md)                                                  | Interactive walkthrough teaching gx features                                                  | Future              | v4      | All stable modules       |
+| [Distribution & Install UX](./modules/15-distribution.aps.md)                             | Release binaries, installer, and doctor flow for easy adoption                                | Draft               | v5      | CLI                      |
+| [Shell Portability](./modules/16-shell-portability.aps.md)                                | Bash/fish integration and completion parity                                                   | Draft               | v5      | Shell Plugin, CLI        |
+| [Index Reliability & Observability](./modules/17-index-observability.aps.md)              | Index diagnostics, stats, and scan telemetry                                                  | Draft               | v5      | Index, Tracking          |
+| [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready               | v6      | CLI, APS scaffolding     |
+| [Fork & Sync](./modules/19-fork.aps.md)                                                   | Fork repos via GitHub, clone locally, and keep forks synced with upstream                     | Draft               | v4      | Clone, Shell Plugin, CLI |
 
 ## Risks
 
-| Risk | Impact | Mitigation |
-|------|--------|------------|
-| Bun compile binary size | Large binary for simple CLI | Acceptable for v1, benchmark and optimize later |
-| URL edge cases | Malformed URLs cause crashes | Port gclone's validation regex, comprehensive test suite |
-| Index name collisions | Two repos with same basename | Last-write-wins for v1, warn on collision |
-| Fuzzy match false positives | Auto-jump to wrong project on weak match | Require high similarity threshold for auto-jump, confirm otherwise |
-| Editor detection fragility | `$EDITOR` not set or points to unknown binary | Maintain known-editor list, fall back to sensible default |
-| Template staleness | Scaffolded CLAUDE.md becomes outdated as conventions change | Keep templates minimal and project-type-specific, easy to regenerate |
-| Dashboard performance at scale | Git status across 100+ repos could be slow | Bounded concurrency (8 parallel), timeout per repo, cache recent results |
-| Index schema migration | Adding `lastVisited` field to existing entries | Make field optional, null = never visited, no migration step required |
-| Hook security surface | Malicious `.gx.json` could run arbitrary commands | direnv-style trust/allow — hooks never run until user explicitly trusts project |
-| TUI terminal compatibility | Escape sequences differ across terminals | Target xterm-256color, degrade gracefully, always provide non-interactive fallback |
+| Risk                           | Impact                                                      | Mitigation                                                                         |
+| ------------------------------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Bun compile binary size        | Large binary for simple CLI                                 | Acceptable for v1, benchmark and optimize later                                    |
+| URL edge cases                 | Malformed URLs cause crashes                                | Port gclone's validation regex, comprehensive test suite                           |
+| Index name collisions          | Two repos with same basename                                | Last-write-wins for v1, warn on collision                                          |
+| Fuzzy match false positives    | Auto-jump to wrong project on weak match                    | Require high similarity threshold for auto-jump, confirm otherwise                 |
+| Editor detection fragility     | `$EDITOR` not set or points to unknown binary               | Maintain known-editor list, fall back to sensible default                          |
+| Template staleness             | Scaffolded CLAUDE.md becomes outdated as conventions change | Keep templates minimal and project-type-specific, easy to regenerate               |
+| Dashboard performance at scale | Git status across 100+ repos could be slow                  | Bounded concurrency (8 parallel), timeout per repo, cache recent results           |
+| Index schema migration         | Adding `lastVisited` field to existing entries              | Make field optional, null = never visited, no migration step required              |
+| Hook security surface          | Malicious `.gx.json` could run arbitrary commands           | direnv-style trust/allow — hooks never run until user explicitly trusts project    |
+| TUI terminal compatibility     | Escape sequences differ across terminals                    | Target xterm-256color, degrade gracefully, always provide non-interactive fallback |
+| `gh` CLI dependency for fork   | Fork requires external tool not all users have              | Check upfront with clear error, `gx clone` still works without `gh`                |
+| Fork sync conflicts            | Rebase/merge on diverged forks can produce conflicts        | Abort cleanly, leave tree in resolvable state, print actionable guidance           |
 
 ## Open Questions
 
@@ -113,11 +119,11 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 
 ## Decisions
 
-- **D-001:** Owner/repo directory structure by default (`owner`), `flat` (repo only) and `host` (host/owner/repo) modes via config — *accepted*
-- **D-002:** github.com as default host for shorthand `user/repo` — *accepted*
-- **D-003:** Binary + multi-shell integration architecture — `gx shell-init` generates eval-able code for zsh, bash, and fish; `plugin/gx.plugin.zsh` is a legacy oh-my-zsh compatibility shim — *accepted*
-- **D-004:** `gx <name>` as default action (jump to project) — *accepted*
-- **D-005:** Dashboard uses local git state only — no remote fetch on `gx dash` (too slow for multi-project scan) — *proposed*
-- **D-006:** `lastVisited` is an optional field on IndexEntry — backward compatible, no migration needed — *proposed*
-- **D-007:** v3 before v4 — tracking and dashboard provide immediate value and inform TUI design — *proposed*
-- **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — *accepted*
+- **D-001:** Owner/repo directory structure by default (`owner`), `flat` (repo only) and `host` (host/owner/repo) modes via config — _accepted_
+- **D-002:** github.com as default host for shorthand `user/repo` — _accepted_
+- **D-003:** Binary + multi-shell integration architecture — `gx shell-init` generates eval-able code for zsh, bash, and fish; `plugin/gx.plugin.zsh` is a legacy oh-my-zsh compatibility shim — _accepted_
+- **D-004:** `gx <name>` as default action (jump to project) — _accepted_
+- **D-005:** Dashboard uses local git state only — no remote fetch on `gx dash` (too slow for multi-project scan) — _proposed_
+- **D-006:** `lastVisited` is an optional field on IndexEntry — backward compatible, no migration needed — _proposed_
+- **D-007:** v3 before v4 — tracking and dashboard provide immediate value and inform TUI design — _proposed_
+- **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — _accepted_

--- a/plans/modules/19-fork.aps.md
+++ b/plans/modules/19-fork.aps.md
@@ -1,0 +1,90 @@
+# Fork & Sync
+
+| ID  | Owner       | Status |
+| --- | ----------- | ------ |
+| FRK | @joshuaboys | Draft  |
+
+## Purpose
+
+Enable users to fork repositories and keep forks in sync with upstream via `gx fork` and `gx sync`. Forking is a first-class GitHub workflow, and gx should handle the full lifecycle: fork on the remote, clone locally, index the project, track the upstream relationship, and provide a simple way to pull upstream changes — even when the fork has diverged.
+
+## In Scope
+
+- `gx fork <repo>` — fork on GitHub via `gh`, clone the fork locally, set `upstream` remote, index the project, cd into it
+- `gx fork <repo> --clone-only` — skip the GitHub fork (repo already forked), just clone your fork and set upstream
+- `gx sync` — fetch upstream and integrate changes into current branch
+- `gx sync` detects fork state and acts accordingly:
+  - **Behind upstream:** fast-forward merge (safe, automatic)
+  - **Ahead of upstream:** nothing to sync — upstream has no new changes, inform user
+  - **Diverged (ahead and behind):** fetch upstream, then rebase or merge based on user preference (default: rebase, configurable)
+- `gx sync --rebase` / `gx sync --merge` — override the default strategy
+- `gx sync --push` — push to origin after syncing (update your remote fork)
+- Detect if `gh` CLI is available and authenticated before forking
+- Tab completion for `gx fork` and `gx sync`
+
+## Out of Scope
+
+- Forking on non-GitHub hosts (GitLab, Bitbucket) — `gh` is GitHub-only
+- Syncing forks that have multiple upstreams or complex remote topologies
+- Automatic periodic sync (cron, background daemon)
+- Pull request creation from fork (`gh pr create` already handles this)
+- Renaming the fork on GitHub
+- Managing fork settings (e.g., disabling issues on the fork)
+
+## Interfaces
+
+**Depends on:**
+
+- Clone (02) — reuses URL parsing, `git clone`, path computation, and indexing
+- Shell Plugin (05) — shell wrapper for `cd` after fork, completion entries
+- CLI (04) — subcommand registration
+
+**Exposes:**
+
+- `forkRepo(input: string, config: Config, indexPath: string, opts?: ForkOptions): Promise<string>` — fork, clone, index, return local path
+- `syncFork(opts?: SyncOptions): Promise<SyncResult>` — fetch upstream, integrate changes, return status
+- `fork` subcommand in CLI
+- `sync` subcommand in CLI
+
+**Types:**
+
+```typescript
+interface ForkOptions {
+  cloneOnly?: boolean; // skip gh fork, just clone + set upstream
+}
+
+interface SyncOptions {
+  strategy?: "rebase" | "merge"; // default: rebase
+  push?: boolean; // push to origin after sync
+}
+
+interface SyncResult {
+  status: "up-to-date" | "fast-forwarded" | "rebased" | "merged" | "conflict";
+  ahead: number; // commits ahead of upstream
+  behind: number; // commits behind upstream
+}
+```
+
+## Constraints
+
+- Requires `gh` CLI installed and authenticated — `gx fork` must check this upfront and give a clear error if missing
+- `gx sync` must never silently discard user commits — diverged state always requires an explicit strategy
+- `gx sync` must abort cleanly on rebase/merge conflicts and leave the working tree in a resolvable state (same as `git rebase` / `git merge` would)
+- `gx sync` only operates on the current branch — does not sync all branches
+- `upstream` remote name is a convention — `gx sync` should detect the upstream remote by checking `gh repo view --json parent` or falling back to a remote named `upstream`
+- Must not break the existing `gx clone` workflow — `gx fork` is an additive command
+
+## Ready Checklist
+
+Change status to **Ready** when:
+
+- [ ] `gh` CLI detection and error messaging designed
+- [ ] Fork-then-clone flow validated (gh fork → parse fork URL → clone → set upstream → index)
+- [ ] Sync strategy for all three states defined (behind, ahead, diverged)
+- [ ] Shell integration (cd + completions) planned
+- [ ] Dependencies identified
+- [ ] At least one work item defined
+
+## Work Items
+
+_None yet -- tasks will be defined when this module reaches Ready status._

--- a/plans/modules/19-fork.aps.md
+++ b/plans/modules/19-fork.aps.md
@@ -68,7 +68,7 @@ interface SyncResult {
 ## Constraints
 
 - Requires `gh` CLI installed and authenticated — `gx fork` must check this upfront and give a clear error if missing
-- `gx sync` must never silently discard user commits — diverged state always requires an explicit strategy
+- `gx sync` must never silently discard user commits — diverged state uses the configured strategy (default: rebase), which can be overridden per-run with `--rebase` / `--merge`; the chosen strategy must be displayed to the user before execution
 - `gx sync` must abort cleanly on rebase/merge conflicts and leave the working tree in a resolvable state (same as `git rebase` / `git merge` would)
 - `gx sync` only operates on the current branch — does not sync all branches
 - `upstream` remote name is a convention — `gx sync` should detect the upstream remote by checking `gh repo view --json parent` or falling back to a remote named `upstream`


### PR DESCRIPTION
## Summary
- Adds APS module 19 (Fork & Sync) covering `gx fork` and `gx sync` commands
- Updates plan index with v4 success criteria, module entry, and risk entries
- Covers GitHub forking via `gh` CLI, upstream remote tracking, and diverged fork sync strategies (rebase/merge)

## Test plan
- [ ] Verify `plans/modules/19-fork.aps.md` follows APS module format
- [ ] Verify `plans/index.aps.md` module table, success criteria, and risks are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)