### PR TITLE
chore: use accessible h1 with logo image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <div align="center">
 
 <h1>
-  <img src="assets/gx-logo.png" alt="" width="400">
-  <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0">gx</span>
+  <img src="assets/gx-logo.png" alt="gx" width="400">
 </h1>
 
 **A fast git project manager.


### PR DESCRIPTION
## Summary
- Wrap the README logo in an `<h1>` element with `alt="gx"` for screen reader accessibility
- Replace the previous approach (which GitHub stripped) with semantic alt text

## Test plan
- [ ] Verify logo renders correctly on the GitHub repo page
- [ ] Verify no visible "gx" text appears alongside the image
- [ ] Confirm screen readers announce "gx" heading via the alt attribute

