### PR TITLE
feat(clone): add defaultOwner config for bare repo names

### DIFF
--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -10,7 +10,7 @@ export async function cloneRepo(
   config: Config,
   indexPath: string,
 ): Promise<string> {
-  const parsed = parseUrl(input, config.defaultHost);
+  const parsed = parseUrl(input, config.defaultHost, config.defaultOwner);
   const targetDir = toPath(parsed, config);
 
   // Check if target already exists (handles .git as dir or file for worktrees)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,8 +46,8 @@ function validateConfig(raw: unknown): Config {
         ? obj.defaultHost
         : DEFAULT_CONFIG.defaultHost,
     defaultOwner:
-      typeof obj.defaultOwner === "string"
-        ? obj.defaultOwner
+      typeof obj.defaultOwner === "string" && obj.defaultOwner.trim()
+        ? obj.defaultOwner.trim()
         : DEFAULT_CONFIG.defaultOwner,
     structure:
       obj.structure === "flat" ||

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -45,6 +45,10 @@ function validateConfig(raw: unknown): Config {
       typeof obj.defaultHost === "string" && obj.defaultHost
         ? obj.defaultHost
         : DEFAULT_CONFIG.defaultHost,
+    defaultOwner:
+      typeof obj.defaultOwner === "string"
+        ? obj.defaultOwner
+        : DEFAULT_CONFIG.defaultOwner,
     structure:
       obj.structure === "flat" ||
       obj.structure === "owner" ||

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -4,6 +4,7 @@ const HTTPS_RE = /^https?:\/\/([^/]+)\/(.+?)(?:\.git)?\/?$/;
 const SSH_RE = /^(?:ssh:\/\/)?[^@]+@([^/:]+)(?::\d+)?[:/](.+?)(?:\.git)?\/?$/;
 const GIT_RE = /^git:\/\/([^/]+)\/(.+?)(?:\.git)?\/?$/;
 const SHORTHAND_RE = /^([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-][a-zA-Z0-9_.\-/]*)$/;
+const BARE_NAME_RE = /^[a-zA-Z0-9_.-]+$/;
 
 function validateSegments(owner: string, repo: string): void {
   for (const seg of [...owner.split("/"), repo]) {
@@ -20,7 +21,11 @@ function extract(match: RegExpMatchArray): [string, string] {
   return [match[1] ?? "", match[2] ?? ""];
 }
 
-export function parseUrl(input: string, defaultHost = "github.com"): ParsedRepo {
+export function parseUrl(
+  input: string,
+  defaultHost = "github.com",
+  defaultOwner = "",
+): ParsedRepo {
   const trimmed = input.trim();
   if (!trimmed) throw new Error("Empty repository URL");
 
@@ -52,6 +57,16 @@ export function parseUrl(input: string, defaultHost = "github.com"): ParsedRepo 
       owner,
       repo,
       originalUrl: `https://${defaultHost}/${owner}/${rawRepo}`,
+    };
+  }
+
+  if (BARE_NAME_RE.test(trimmed) && defaultOwner) {
+    validateSegments(defaultOwner, trimmed);
+    return {
+      host: defaultHost,
+      owner: defaultOwner,
+      repo: trimmed,
+      originalUrl: `https://${defaultHost}/${defaultOwner}/${trimmed}`,
     };
   }
 

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -60,13 +60,19 @@ export function parseUrl(
     };
   }
 
-  if (BARE_NAME_RE.test(trimmed) && defaultOwner) {
-    validateSegments(defaultOwner, trimmed);
+  if (BARE_NAME_RE.test(trimmed)) {
+    if (!defaultOwner) {
+      throw new Error(
+        `Bare repo name "${trimmed}" requires defaultOwner — run: gx config set defaultOwner <owner>`,
+      );
+    }
+    const repo = trimmed.replace(/\.git$/, "");
+    validateSegments(defaultOwner, repo);
     return {
       host: defaultHost,
       owner: defaultOwner,
-      repo: trimmed,
-      originalUrl: `https://${defaultHost}/${defaultOwner}/${trimmed}`,
+      repo,
+      originalUrl: `https://${defaultHost}/${defaultOwner}/${repo}`,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Config {
   projectDir: string;
   defaultHost: string;
+  defaultOwner: string;
   structure: "flat" | "owner" | "host";
   shallow: boolean;
   similarityThreshold: number;
@@ -10,6 +11,7 @@ export interface Config {
 export const DEFAULT_CONFIG: Config = {
   projectDir: "~/Projects/src",
   defaultHost: "github.com",
+  defaultOwner: "",
   structure: "owner",
   shallow: false,
   similarityThreshold: 0.7,

--- a/tests/lib/config.extra.test.ts
+++ b/tests/lib/config.extra.test.ts
@@ -78,6 +78,20 @@ describe("loadConfig validation", () => {
     expect(config.projectDir).toBe("~/Projects/src");
   });
 
+  test("trims whitespace-only defaultOwner to empty string", async () => {
+    const configPath = join(tmpDir, "config.json");
+    await Bun.write(configPath, JSON.stringify({ defaultOwner: "  " }));
+    const config = await loadConfig(configPath);
+    expect(config.defaultOwner).toBe("");
+  });
+
+  test("trims surrounding whitespace from defaultOwner", async () => {
+    const configPath = join(tmpDir, "config.json");
+    await Bun.write(configPath, JSON.stringify({ defaultOwner: " eddacraft " }));
+    const config = await loadConfig(configPath);
+    expect(config.defaultOwner).toBe("eddacraft");
+  });
+
   test("accepts valid config values", async () => {
     const configPath = join(tmpDir, "config.json");
     const custom = {

--- a/tests/lib/config.extra.test.ts
+++ b/tests/lib/config.extra.test.ts
@@ -83,6 +83,7 @@ describe("loadConfig validation", () => {
     const custom = {
       projectDir: "/custom/path",
       defaultHost: "gitlab.com",
+      defaultOwner: "",
       structure: "host" as const,
       shallow: true,
       similarityThreshold: 0.8,

--- a/tests/lib/url.test.ts
+++ b/tests/lib/url.test.ts
@@ -75,12 +75,18 @@ test("explicit owner/repo takes precedence over defaultOwner", () => {
   expect(result.repo).toBe("thing");
 });
 
-test("bare repo name without defaultOwner throws", () => {
-  expect(() => parseUrl("anvil")).toThrow();
+test("bare repo name strips .git suffix", () => {
+  const result = parseUrl("anvil.git", "github.com", "eddacraft");
+  expect(result.repo).toBe("anvil");
+  expect(result.originalUrl).toBe("https://github.com/eddacraft/anvil");
 });
 
-test("bare repo name with empty defaultOwner throws", () => {
-  expect(() => parseUrl("anvil", "github.com", "")).toThrow();
+test("bare repo name without defaultOwner gives actionable error", () => {
+  expect(() => parseUrl("anvil")).toThrow(/defaultOwner/);
+});
+
+test("bare repo name with empty defaultOwner gives actionable error", () => {
+  expect(() => parseUrl("anvil", "github.com", "")).toThrow(/defaultOwner/);
 });
 
 // Errors

--- a/tests/lib/url.test.ts
+++ b/tests/lib/url.test.ts
@@ -60,6 +60,29 @@ test("parses URL with nested path (gitlab groups)", () => {
   expect(result.repo).toBe("repo");
 });
 
+// Bare repo name with defaultOwner
+test("parses bare repo name using defaultOwner", () => {
+  const result = parseUrl("anvil", "github.com", "eddacraft");
+  expect(result.host).toBe("github.com");
+  expect(result.owner).toBe("eddacraft");
+  expect(result.repo).toBe("anvil");
+  expect(result.originalUrl).toBe("https://github.com/eddacraft/anvil");
+});
+
+test("explicit owner/repo takes precedence over defaultOwner", () => {
+  const result = parseUrl("joshuaboys/thing", "github.com", "eddacraft");
+  expect(result.owner).toBe("joshuaboys");
+  expect(result.repo).toBe("thing");
+});
+
+test("bare repo name without defaultOwner throws", () => {
+  expect(() => parseUrl("anvil")).toThrow();
+});
+
+test("bare repo name with empty defaultOwner throws", () => {
+  expect(() => parseUrl("anvil", "github.com", "")).toThrow();
+});
+
 // Errors
 test("throws on empty input", () => {
   expect(() => parseUrl("")).toThrow();


### PR DESCRIPTION
## Summary
- Adds `defaultOwner` config option so `gx clone anvil` resolves to `<defaultOwner>/anvil` without needing to type the owner every time
- Explicit `owner/repo` shorthand and full URLs take precedence over the default
- Particularly useful with `flat` directory structure where the owner is only needed for the git URL

## Usage
```sh
gx config set defaultOwner eddacraft
gx clone anvil          # clones eddacraft/anvil
gx clone joshuaboys/gx  # explicit owner still works
```

## Test plan
- [x] Bare repo name resolves with `defaultOwner` set
- [x] Explicit `owner/repo` takes precedence over `defaultOwner`
- [x] Bare repo name throws when no `defaultOwner` configured
- [x] Bare repo name throws when `defaultOwner` is empty string
- [x] Full test suite passes (214 tests)