### PR TITLE
RFC: Port gx from TypeScript/Bun to Rust

### DIFF
--- a/plans/decisions/010-rust-port.md
+++ b/plans/decisions/010-rust-port.md
@@ -78,17 +78,17 @@ These are the invariants the snapshot harness enforces:
 
 **Neutral**
 
-- TS implementation stays buildable through phase 5; the experiment is reversible
+- TS implementation stays buildable through phase RST-6; the experiment is reversible
 - Shell-plugin users see no change while `shell-init` output is preserved verbatim
 
 ## Open Questions
 
 - **Q-1:** Workspace layout — single crate at root vs. `crates/gx/` with virtual manifest. Recommendation: start single-crate, restructure when a second crate exists.
-- **Q-2:** Bin name during transition — ship as `gx-rs` for one release before promoting, or feature-flag a single binary? Recommendation: `gx-rs` shadow release, then promote at phase 7.
+- **Q-2:** Bin name during transition — ship as `gx-rs` for one release before promoting, or feature-flag a single binary? Recommendation: `gx-rs` shadow release, then promote at phase RST-7.
 - **Q-3:** MSRV — pin to the current stable at port time (likely 1.75+), no nightly features.
 - **Q-4:** `gx shell-init` — verbatim port (chosen) vs. switch to `clap_complete`. Verbatim wins because user shells already eval the existing strings.
-- **Q-5:** Windows — produce binaries in CI from phase 7, but defer `install.sh` Windows support to a separate effort.
+- **Q-5:** Windows — produce binaries in CI from phase RST-7, but defer `install.sh` Windows support to a separate effort.
 
 ## Supersedes
 
-This decision modifies the constraint in `index.aps.md` ("TypeScript + Bun only (no Go, no Node)") to "Rust only (no JS runtime)" once the port reaches phase 6 (TS source removed).
+This decision modifies the constraint in `index.aps.md` ("TypeScript + Bun only (no Go, no Node)") to "Rust only (no JS runtime)" once the port reaches phase RST-7 (TS source removed).

--- a/plans/decisions/010-rust-port.md
+++ b/plans/decisions/010-rust-port.md
@@ -1,0 +1,94 @@
+# D-010: Port gx from TypeScript/Bun to Rust
+
+| Status   | Date       | Owner       |
+| -------- | ---------- | ----------- |
+| Proposed | 2026-05-03 | @joshuaboys |
+
+## Context
+
+gx today is a TypeScript CLI compiled to a single binary by `bun build --compile`. The architecture has served v1–v3, but several frictions are accumulating:
+
+- **Binary size.** A `bun --compile` artifact embeds the Bun runtime — current artifacts run 50–90 MB for ~1.8K LOC of source. `index.aps.md` already flags this in its risk table.
+- **Cold-start latency.** Shell completions call `gx resolve --list` on every Tab. Bun's startup is fast for a JS runtime, but a Rust binary is an order of magnitude faster, which matters at this call frequency.
+- **Build-time dependencies.** Contributors and CI need Bun. `install.sh` falls back to "install Bun, then build" when no prebuilt asset exists. A statically linked Rust binary removes that fallback path.
+- **Cross-compilation.** Bun does not produce Windows binaries. Rust does. `install.sh` does not currently target Windows, but the binary should not be the blocker.
+- **Test infrastructure.** `bun:test` is fine but ties tests to Bun. `cargo test` is hermetic on every supported platform with no external setup.
+
+## Decision
+
+Port gx to Rust under strict behavior parity. The port:
+
+- Replaces the Bun toolchain entirely; the shipped binary is `cargo build --release` output
+- Preserves the CLI surface, `~/.config/gx/{config,index}.json` schemas, and `gx shell-init` output verbatim
+- Keeps git operations as `git` subprocess calls (no `git2`/libgit2)
+- Stays synchronous (no `tokio`) until a feature actually needs concurrency
+- Lands incrementally on a long-lived `rust-port` branch with a snapshot harness asserting every command's output matches the TS binary's, so the work is reversible at any phase boundary
+
+Work is tracked under module `RST` (`plans/modules/20-rust-port.aps.md`) in seven phases (RST-1 through RST-7).
+
+## Crate Selection
+
+| Concern             | Choice                              | Rationale                                                                                                  |
+| ------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| CLI parsing         | `clap` 4 (derive)                   | Mature, ergonomic, generates good `--help`                                                                 |
+| JSON                | `serde` + `serde_json`              | Pretty-print matches TS `JSON.stringify(.., null, 2)` output                                               |
+| Atomic file writes  | `tempfile::NamedTempFile`           | Same-dir tempfile + atomic rename; preserves the current invariant                                         |
+| Filesystem walk     | `walkdir`                           | Configurable depth and skip rules; canonicalise for symlink-cycle detection                                |
+| Regex               | `regex`                             | URL, agent, and segment validation                                                                         |
+| Path utilities      | `std::path` + `dirs`                | `dirs::home_dir()` replaces `os.homedir()`                                                                 |
+| Errors              | `thiserror`                         | Typed errors with `exit_code()`; `anyhow` only at `main`                                                   |
+| Fuzzy matching      | hand-port of the current Jaro-Winkler | TS impl is case-insensitive with prefix cap of 4 and `p=0.1`; verify against `strsim` before substituting |
+| Tests               | `assert_cmd` + `insta` + `tempfile` | End-to-end snapshots match the parity-first plan                                                           |
+
+Explicitly rejected:
+
+- **`git2`/libgit2** — adds a C dependency for one-shot subprocess workloads
+- **`tokio`** — premature; no current command benefits
+- **`clap_complete` for `gx shell-init`** — would change the verbatim output users have already added to their shells
+
+## Behavior Parity Contracts
+
+These are the invariants the snapshot harness enforces:
+
+1. `~/.config/gx/index.json` and `~/.config/gx/config.json` schemas — field names, types, defaults, JSON formatting (2-space indent, trailing newline)
+2. `gx resolve <name>` writes the path to stdout and hints to stderr; shell wrappers depend on this split
+3. `gx clone` writes the final path to stdout; shell wrappers `cd` into it
+4. `gx shell-init {zsh,bash,fish}` output is byte-identical
+5. Atomic index save (temp file in the same directory, then rename)
+6. Path-traversal validation: `..`, `.`, empty segments, backslash, NUL all rejected
+7. Fuzzy thresholds: `0.7` similarity default, `0.85` auto-jump
+8. Exit codes: `CommandError(message, exitCode=1)` semantics map to typed errors with `exit_code()` defaulting to 1
+9. `GX_AGENT` validation regex unchanged
+
+## Consequences
+
+**Positive**
+
+- Smaller binaries, faster cold starts, simpler install flow
+- Removes Bun as a contributor and CI prerequisite
+- Opens a path to Windows support
+- Standard Rust tooling (`cargo`, `rustfmt`, `clippy`) replaces a Bun-specific toolchain
+
+**Negative**
+
+- Source size grows roughly 1.5–2× due to explicit error types and trait boilerplate
+- Loses Bun-native conveniences (`Bun.file`, `Bun.spawn`, `Bun.write`)
+- Cultural shift: `AGENTS.md` and project conventions need rewriting
+- Contributor pool now needs Rust familiarity rather than TypeScript
+
+**Neutral**
+
+- TS implementation stays buildable through phase 5; the experiment is reversible
+- Shell-plugin users see no change while `shell-init` output is preserved verbatim
+
+## Open Questions
+
+- **Q-1:** Workspace layout — single crate at root vs. `crates/gx/` with virtual manifest. Recommendation: start single-crate, restructure when a second crate exists.
+- **Q-2:** Bin name during transition — ship as `gx-rs` for one release before promoting, or feature-flag a single binary? Recommendation: `gx-rs` shadow release, then promote at phase 7.
+- **Q-3:** MSRV — pin to the current stable at port time (likely 1.75+), no nightly features.
+- **Q-4:** `gx shell-init` — verbatim port (chosen) vs. switch to `clap_complete`. Verbatim wins because user shells already eval the existing strings.
+- **Q-5:** Windows — produce binaries in CI from phase 7, but defer `install.sh` Windows support to a separate effort.
+
+## Supersedes
+
+This decision modifies the constraint in `index.aps.md` ("TypeScript + Bun only (no Go, no Node)") to "Rust only (no JS runtime)" once the port reaches phase 6 (TS source removed).

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -83,7 +83,7 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 | [Index Reliability & Observability](./modules/17-index-observability.aps.md)              | Index diagnostics, stats, and scan telemetry                                                  | Draft               | v5      | Index, Tracking          |
 | [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready               | v6      | CLI, APS scaffolding     |
 | [Fork & Sync](./modules/19-fork.aps.md)                                                   | Fork repos via GitHub, clone locally, and keep forks synced with upstream                     | Draft               | v4      | Clone, Shell Plugin, CLI |
-| [Rust Port](./modules/20-rust-port.aps.md)                                                | Re-implement gx as a Rust binary with full behavior parity                                    | Draft               | v6      | All                      |
+| [Rust Port](./modules/20-rust-port.aps.md)                                                | Re-implement gx as a Rust binary with full behavior parity                                    | Draft               | v5      | All                      |
 
 ## Risks
 

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -83,6 +83,7 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 | [Index Reliability & Observability](./modules/17-index-observability.aps.md)              | Index diagnostics, stats, and scan telemetry                                                  | Draft               | v5      | Index, Tracking          |
 | [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready               | v6      | CLI, APS scaffolding     |
 | [Fork & Sync](./modules/19-fork.aps.md)                                                   | Fork repos via GitHub, clone locally, and keep forks synced with upstream                     | Draft               | v4      | Clone, Shell Plugin, CLI |
+| [Rust Port](./modules/20-rust-port.aps.md)                                                | Re-implement gx as a Rust binary with full behavior parity                                    | Draft               | v6      | All                      |
 
 ## Risks
 
@@ -128,3 +129,4 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - **D-009:** No separate `gx touch` command — `resolve` updates `lastVisited` as a side effect, eliminating a subprocess spawn per navigation — _accepted_
 - **D-007:** v3 before v4 — tracking and dashboard provide immediate value and inform TUI design — _proposed_
 - **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — _accepted_
+- **D-010:** Port gx to Rust with strict behavior parity, preserving CLI surface, config and index schemas, and `gx shell-init` output (see `decisions/010-rust-port.md`) — _proposed_

--- a/plans/modules/20-rust-port.aps.md
+++ b/plans/modules/20-rust-port.aps.md
@@ -1,0 +1,81 @@
+# Rust Port
+
+| ID  | Owner       | Status |
+| --- | ----------- | ------ |
+| RST | @joshuaboys | Draft  |
+
+## Purpose
+
+Re-implement gx as a Rust binary that is byte-for-byte compatible with the current TypeScript implementation: same CLI surface, same `~/.config/gx/` schemas, same `gx shell-init` output. This removes the 50–90 MB Bun-compile binary, drops Bun as a contributor and CI prerequisite, opens a path to Windows support, and lowers cold-start latency on every shell-completion call.
+
+## In Scope
+
+- Port every shipped command: `clone`, `ls`, `index`, `rebuild`, `config`, `open`, `init`, `shell-init`, `resolve`, `recent`, `resume`
+- Port every library module: URL parsing, path mapping, fuzzy matching, project index (load/save/scan/rebuild), name resolution, project-type detection, templates, time formatting, errors
+- Reproduce `index.json` and `config.json` schemas exactly (field names, types, defaults, JSON formatting)
+- Reproduce `gx shell-init` output verbatim for zsh, bash, and fish
+- Snapshot harness that captures the TS binary's output and asserts the Rust binary matches
+- Cargo-based CI matrix replacing Bun on `ubuntu-latest` and `macos-latest`
+- Cross-compiled prebuilt assets for `linux-x64`, `linux-aarch64`, `darwin-x64`, `darwin-aarch64`
+- Update `install.sh` to fetch new asset names and drop the Bun build-from-source fallback
+- Rewrite `AGENTS.md` for Rust conventions
+
+## Out of Scope
+
+- Any v3+ planned feature (`fork`, `sync`, `dash`, hooks, TUI, tutorial) — port first, build new features after
+- Any behavior change (different defaults, new flags, different error messages or exit codes)
+- Switching `gx shell-init` output to clap-generated completions
+- Adding async or parallelism — every current command is sequential
+- Windows support in `install.sh` (the Rust binary will compile for Windows, but installer work is deferred)
+- Replacing git subprocess calls with libgit2
+
+## Interfaces
+
+**Depends on:**
+
+- Every existing module — this is a wholesale re-implementation rather than a new feature
+
+**Exposes (post-port):**
+
+- A `gx` binary on `$PATH` with identical CLI behavior
+- The same `~/.config/gx/{config,index}.json` schemas
+- The same shell wrapper code emitted by `gx shell-init`
+
+## Constraints
+
+- **Behavior parity:** any deviation from the TS binary in stdout, stderr, exit code, file contents, or shell-init output is a regression and must be fixed before that command's port can land
+- **Schema parity:** an `index.json` written by either binary must round-trip through the other without semantic change
+- **Atomic saves preserved:** `index.json` writes must continue to use temp-file-then-rename inside the same directory
+- **Path-traversal validation preserved:** `..`, `.`, empty-segment, backslash, and NUL guards in URL parsing must be ported character-for-character
+- **Fuzzy thresholds preserved:** `similarityThreshold = 0.7` default and `AUTO_JUMP_THRESHOLD = 0.85` constant
+- **Git via subprocess only:** no `git2`/libgit2 dependency
+- **No async runtime:** stay synchronous; defer `tokio` until a feature actually needs concurrency (`gx dash`)
+- **Reversible:** TS source must remain buildable through phases 0–5 so the experiment can be abandoned
+
+## Ready Checklist
+
+Change status to **Ready** when:
+
+- [x] Decision recorded as ADR — see `decisions/010-rust-port.md`
+- [ ] Crate selection finalised (clap, serde, serde_json, walkdir, tempfile, regex, thiserror, dirs)
+- [ ] Snapshot-harness shape agreed (`assert_cmd` + `insta`, fixtures under `tests/fixtures/`)
+- [ ] Workspace layout decided (single crate at root vs. `crates/gx/` with virtual manifest)
+- [ ] Phase ordering validated against module dependencies
+- [ ] Distribution asset naming agreed (preserve `gx-{linux,darwin}-{x64,aarch64}`)
+
+## Work Items
+
+- [ ] **RST-1:** Cargo scaffolding and CI matrix
+  - Cargo manifest, empty binary, `cargo {fmt,clippy,test,build}` jobs added to `ci.yml`
+- [ ] **RST-2:** Snapshot harness against the current TS binary
+  - Fixture index/config and golden outputs committed for every command; harness reproduces them when run against the TS binary
+- [ ] **RST-3:** Pure-logic ports
+  - `url`, `path`, `fuzzy`, `time`, `detect`, `templates`, `types`, `config` ported with unit tests mirroring `tests/lib/`
+- [ ] **RST-4:** `index_store` port
+  - Load, save, scan, additive and scoped rebuild ported; round-trips a real `index.json` byte-equal; symlink-cycle test passes
+- [ ] **RST-5:** Read-only commands
+  - `ls`, `recent`, `resolve`, `config`, `shell-init` wired through clap; snapshot harness green
+- [ ] **RST-6:** Mutating commands
+  - `clone`, `init`, `index`, `rebuild`, `open`, `resume` ported; full snapshot harness green; manual smoke on real repos
+- [ ] **RST-7:** Distribution cutover
+  - `install.sh` and release workflow ship the Rust binary; TS source removed; `AGENTS.md` rewritten for Rust

--- a/plans/modules/20-rust-port.aps.md
+++ b/plans/modules/20-rust-port.aps.md
@@ -50,7 +50,7 @@ Re-implement gx as a Rust binary that is byte-for-byte compatible with the curre
 - **Fuzzy thresholds preserved:** `similarityThreshold = 0.7` default and `AUTO_JUMP_THRESHOLD = 0.85` constant
 - **Git via subprocess only:** no `git2`/libgit2 dependency
 - **No async runtime:** stay synchronous; defer `tokio` until a feature actually needs concurrency (`gx dash`)
-- **Reversible:** TS source must remain buildable through phases 0–5 so the experiment can be abandoned
+- **Reversible:** TS source must remain buildable through phase RST-6 so the experiment can be abandoned (RST-7 is the cutover that removes it)
 
 ## Ready Checklist
 


### PR DESCRIPTION
## Summary

This PR proposes a comprehensive decision and implementation plan to port gx from TypeScript/Bun to Rust. The port aims to address accumulated friction in the current architecture while maintaining strict behavior parity with the existing implementation.

## Changes

- **Decision Document (D-010):** Establishes the rationale for the port, including:
  - Problem statement: binary size (50–90 MB), cold-start latency, build-time dependencies, cross-compilation limitations, and test infrastructure coupling
  - Crate selection with explicit rationale (clap, serde, serde_json, tempfile, walkdir, regex, thiserror, dirs)
  - Behavior parity contracts ensuring the Rust binary is byte-for-byte compatible with the TS implementation
  - Consequences and open questions (workspace layout, bin naming during transition, MSRV, Windows support timeline)

- **Module Plan (RST):** Defines the seven-phase implementation roadmap:
  - **RST-1:** Cargo scaffolding and CI matrix
  - **RST-2:** Snapshot harness against the current TS binary
  - **RST-3:** Pure-logic ports (url, path, fuzzy, time, detect, templates, types, config)
  - **RST-4:** Index store port with round-trip validation
  - **RST-5:** Read-only commands (ls, recent, resolve, config, shell-init)
  - **RST-6:** Mutating commands (clone, init, index, rebuild, open, resume)
  - **RST-7:** Distribution cutover and TS source removal

- **Index Update:** Registers the Rust Port module in the main planning index with v6 target and appropriate categorization.

## Notable Implementation Details

- **Behavior Parity First:** A snapshot harness will enforce that every command's output matches the TS binary's, making the work reversible at any phase boundary
- **Incremental Landing:** Work lands on a long-lived `rust-port` branch with TS source remaining buildable through phase RST-6
- **Explicit Rejections:** `git2`/libgit2 (subprocess calls only), `tokio` (synchronous until needed), and `clap_complete` (preserves verbatim shell-init output)
- **Reversibility:** TS implementation stays buildable through phase RST-6; the experiment can be abandoned without disruption
- **Windows Path:** Rust binary will compile for Windows from phase RST-7, but `install.sh` Windows support is deferred to a separate effort
