### PR TITLE
build(rust): RST-1 cargo scaffolding and CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,18 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # The parity harness in crates/gx/tests/parity.rs spawns the TS gx
+      # binary to verify the Rust port's snapshot contract. Build it here so
+      # cargo test can find it at the workspace root.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build TS binary for parity tests
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
       - name: Format check
         run: cargo fmt --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.75
         with:
           components: rustfmt, clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,48 +12,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "assert_cmd"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
-dependencies = [
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
-]
 
 [[package]]
 name = "cfg-if"
@@ -71,12 +39,6 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
-
-[[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "encode_unicode"
@@ -129,7 +91,6 @@ dependencies = [
 name = "gx"
 version = "0.0.0"
 dependencies = [
- "assert_cmd",
  "insta",
  "tempfile",
 ]
@@ -227,33 +188,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "predicates"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
-dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "prettyplease"
@@ -410,12 +344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,15 +354,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,602 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "gx"
 version = "0.0.0"
+dependencies = [
+ "assert_cmd",
+ "insta",
+ "tempfile",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "regex",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/gx/Cargo.toml
+++ b/crates/gx/Cargo.toml
@@ -15,3 +15,6 @@ path = "src/main.rs"
 [dependencies]
 
 [dev-dependencies]
+assert_cmd = "2"
+insta = { version = "1", features = ["filters"] }
+tempfile = "3"

--- a/crates/gx/Cargo.toml
+++ b/crates/gx/Cargo.toml
@@ -15,6 +15,5 @@ path = "src/main.rs"
 [dependencies]
 
 [dev-dependencies]
-assert_cmd = "2"
 insta = { version = "1", features = ["filters"] }
 tempfile = "3"

--- a/crates/gx/tests/fixtures/home/.config/gx/config.json
+++ b/crates/gx/tests/fixtures/home/.config/gx/config.json
@@ -1,0 +1,9 @@
+{
+  "projectDir": "/projects",
+  "defaultHost": "github.com",
+  "defaultOwner": "owner",
+  "structure": "owner",
+  "shallow": false,
+  "similarityThreshold": 0.7,
+  "editor": "nvim"
+}

--- a/crates/gx/tests/fixtures/home/.config/gx/index.json
+++ b/crates/gx/tests/fixtures/home/.config/gx/index.json
@@ -1,0 +1,27 @@
+{
+  "projects": {
+    "alpha": {
+      "path": "/projects/owner/alpha",
+      "url": "https://github.com/owner/alpha.git",
+      "clonedAt": "2026-01-15T10:30:00.000Z",
+      "lastVisited": "2026-05-10T08:00:00.000Z"
+    },
+    "beta": {
+      "path": "/projects/owner/beta",
+      "url": "https://github.com/owner/beta.git",
+      "clonedAt": "2026-02-20T14:15:00.000Z",
+      "lastVisited": "2026-05-15T12:00:00.000Z"
+    },
+    "gamma": {
+      "path": "/projects/other/gamma",
+      "url": "git@github.com:other/gamma.git",
+      "clonedAt": "2026-03-01T09:00:00.000Z"
+    },
+    "delta-svc": {
+      "path": "/projects/owner/delta-svc",
+      "url": "https://github.com/owner/delta-svc.git",
+      "clonedAt": "2026-04-05T16:45:00.000Z",
+      "lastVisited": "2026-05-18T20:00:00.000Z"
+    }
+  }
+}

--- a/crates/gx/tests/parity.rs
+++ b/crates/gx/tests/parity.rs
@@ -1,0 +1,249 @@
+//! Parity harness: spawns whichever `gx` binary `GX_BIN` (or the default
+//! workspace-root `./gx`) points at, against a hermetic fixture HOME, and
+//! snapshots stdout / stderr / exit-code / mutated index state.
+//!
+//! Today the only binary the harness runs against is the TS build of `gx`
+//! (`bun run build`). As Rust ports of commands land in RST-5/6, CI re-runs
+//! the same suite against `target/release/gx` and must reproduce every
+//! snapshot.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use insta::{assert_snapshot, with_settings};
+use tempfile::TempDir;
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at crates/gx; go up two levels.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+fn gx_bin() -> PathBuf {
+    if let Ok(p) = std::env::var("GX_BIN") {
+        return PathBuf::from(p);
+    }
+    let candidate = workspace_root().join("gx");
+    assert!(
+        candidate.exists(),
+        "TS gx binary not found at {}. Run `bun run build` at the workspace root, or set GX_BIN.",
+        candidate.display()
+    );
+    candidate
+}
+
+fn fixture_home() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/home")
+}
+
+struct Env {
+    home: PathBuf,
+    // Held to keep the tempdir alive for the duration of the test.
+    _tmp: TempDir,
+}
+
+impl Env {
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path().to_path_buf();
+        // Copy the fixture's ~/.config/gx/ into the temp HOME.
+        let src = fixture_home().join(".config/gx");
+        let dst = home.join(".config/gx");
+        std::fs::create_dir_all(&dst).expect("mkdir config");
+        for entry in std::fs::read_dir(&src).expect("read fixture") {
+            let entry = entry.expect("dirent");
+            std::fs::copy(entry.path(), dst.join(entry.file_name())).expect("copy fixture");
+        }
+        Self { home, _tmp: tmp }
+    }
+
+    fn index_json(&self) -> String {
+        std::fs::read_to_string(self.home.join(".config/gx/index.json")).unwrap_or_default()
+    }
+
+    fn config_json(&self) -> String {
+        std::fs::read_to_string(self.home.join(".config/gx/config.json")).unwrap_or_default()
+    }
+}
+
+struct Run {
+    stdout: String,
+    stderr: String,
+    code: i32,
+}
+
+fn run(env: &Env, args: &[&str]) -> Run {
+    // PATH excludes anything containing `gx`, so `shell-init`'s `which gx`
+    // lookup falls back deterministically to the bare string "gx".
+    let path = "/usr/bin:/bin";
+
+    let out = Command::new(gx_bin())
+        .args(args)
+        .env_remove("GX_AGENT")
+        .env_remove("GX_SHELL_OVERRIDE")
+        .env_remove("VISUAL")
+        .env_remove("EDITOR")
+        .env("HOME", &env.home)
+        .env("PATH", path)
+        // SHELL is read by `shell-init` when no arg is given; fix it so a
+        // bare `shell-init` invocation is deterministic.
+        .env("SHELL", "/bin/zsh")
+        .output()
+        .expect("spawn gx");
+
+    Run {
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        code: out.status.code().unwrap_or(-1),
+    }
+}
+
+fn timestamp_filters() -> Vec<(&'static str, &'static str)> {
+    vec![
+        // ISO 8601 timestamps inside JSON values.
+        (
+            r#""(lastVisited|clonedAt)": "[^"]+""#,
+            r#""$1": "<TIMESTAMP>""#,
+        ),
+        // Relative-time strings emitted by `recent`.
+        (
+            r"\d+ (minute|hour|day|week|month)s? ago|just now",
+            "<RELATIVE>",
+        ),
+    ]
+}
+
+fn assert_run(name: &str, run: &Run) {
+    with_settings!({
+        filters => timestamp_filters(),
+    }, {
+        assert_snapshot!(format!("{name}.stdout"), run.stdout);
+        assert_snapshot!(format!("{name}.stderr"), run.stderr);
+        assert_snapshot!(format!("{name}.exit"), run.code.to_string());
+    });
+}
+
+fn assert_index(name: &str, env: &Env) {
+    with_settings!({
+        filters => timestamp_filters(),
+    }, {
+        assert_snapshot!(format!("{name}.index.json"), env.index_json());
+    });
+}
+
+// --- read-only / informational ---
+
+#[test]
+fn help_flag() {
+    let env = Env::new();
+    let r = run(&env, &["--help"]);
+    assert_run("help_flag", &r);
+}
+
+#[test]
+fn version_flag() {
+    let env = Env::new();
+    let r = run(&env, &["--version"]);
+    assert_run("version_flag", &r);
+}
+
+#[test]
+fn config_show() {
+    let env = Env::new();
+    let r = run(&env, &["config"]);
+    assert_run("config_show", &r);
+}
+
+#[test]
+fn ls() {
+    let env = Env::new();
+    let r = run(&env, &["ls"]);
+    assert_run("ls", &r);
+}
+
+#[test]
+fn recent_unlimited() {
+    let env = Env::new();
+    let r = run(&env, &["recent"]);
+    assert_run("recent_unlimited", &r);
+}
+
+#[test]
+fn recent_limit_2() {
+    let env = Env::new();
+    let r = run(&env, &["recent", "-n", "2"]);
+    assert_run("recent_limit_2", &r);
+}
+
+// --- resolve (mutates lastVisited as a side effect) ---
+
+#[test]
+fn resolve_exact() {
+    let env = Env::new();
+    let r = run(&env, &["resolve", "alpha"]);
+    assert_run("resolve_exact", &r);
+    assert_index("resolve_exact", &env);
+}
+
+#[test]
+fn resolve_fuzzy_auto() {
+    // "alphaa" is a near-prefix match for "alpha" (Jaro-Winkler ≥ 0.85) so
+    // resolve should auto-jump and write `Fuzzy match: …` to stderr.
+    let env = Env::new();
+    let r = run(&env, &["resolve", "alphaa"]);
+    assert_run("resolve_fuzzy_auto", &r);
+}
+
+#[test]
+fn resolve_missing() {
+    let env = Env::new();
+    let r = run(&env, &["resolve", "zzz-no-match"]);
+    assert_run("resolve_missing", &r);
+}
+
+#[test]
+fn resolve_list() {
+    let env = Env::new();
+    let r = run(&env, &["resolve", "--list"]);
+    assert_run("resolve_list", &r);
+}
+
+// --- shell-init ---
+
+#[test]
+fn shell_init_zsh() {
+    let env = Env::new();
+    let r = run(&env, &["shell-init", "zsh"]);
+    assert_run("shell_init_zsh", &r);
+}
+
+#[test]
+fn shell_init_bash() {
+    let env = Env::new();
+    let r = run(&env, &["shell-init", "bash"]);
+    assert_run("shell_init_bash", &r);
+}
+
+#[test]
+fn shell_init_fish() {
+    let env = Env::new();
+    let r = run(&env, &["shell-init", "fish"]);
+    assert_run("shell_init_fish", &r);
+}
+
+// --- config set (mutates config.json) ---
+
+#[test]
+fn config_set_editor() {
+    let env = Env::new();
+    let r = run(&env, &["config", "set", "editor", "code"]);
+    assert_run("config_set_editor", &r);
+    with_settings!({
+        filters => timestamp_filters(),
+    }, {
+        assert_snapshot!("config_set_editor.config.json", env.config_json());
+    });
+}

--- a/crates/gx/tests/parity.rs
+++ b/crates/gx/tests/parity.rs
@@ -22,17 +22,20 @@ fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn gx_bin() -> PathBuf {
+fn gx_bin() -> Option<PathBuf> {
     if let Ok(p) = std::env::var("GX_BIN") {
-        return PathBuf::from(p);
+        return Some(PathBuf::from(p));
     }
     let candidate = workspace_root().join("gx");
-    assert!(
-        candidate.exists(),
-        "TS gx binary not found at {}. Run `bun run build` at the workspace root, or set GX_BIN.",
+    if candidate.exists() {
+        return Some(candidate);
+    }
+
+    eprintln!(
+        "skipping parity test: TS gx binary not found at {}. Run `bun run build` at the workspace root, or set GX_BIN.",
         candidate.display()
     );
-    candidate
+    None
 }
 
 fn fixture_home() -> PathBuf {
@@ -75,12 +78,13 @@ struct Run {
     code: i32,
 }
 
-fn run(env: &Env, args: &[&str]) -> Run {
+fn run(env: &Env, args: &[&str]) -> Option<Run> {
     // PATH excludes anything containing `gx`, so `shell-init`'s `which gx`
     // lookup falls back deterministically to the bare string "gx".
     let path = "/usr/bin:/bin";
+    let gx_bin = gx_bin()?;
 
-    let out = Command::new(gx_bin())
+    let out = Command::new(gx_bin)
         .args(args)
         .env_remove("GX_AGENT")
         .env_remove("GX_SHELL_OVERRIDE")
@@ -94,11 +98,20 @@ fn run(env: &Env, args: &[&str]) -> Run {
         .output()
         .expect("spawn gx");
 
-    Run {
+    Some(Run {
         stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
         code: out.status.code().unwrap_or(-1),
-    }
+    })
+}
+
+macro_rules! run_or_skip {
+    ($env:expr, [$($arg:expr),* $(,)?]) => {
+        match run(&$env, &[$($arg),*]) {
+            Some(run) => run,
+            None => return,
+        }
+    };
 }
 
 fn timestamp_filters() -> Vec<(&'static str, &'static str)> {
@@ -139,42 +152,42 @@ fn assert_index(name: &str, env: &Env) {
 #[test]
 fn help_flag() {
     let env = Env::new();
-    let r = run(&env, &["--help"]);
+    let r = run_or_skip!(env, ["--help"]);
     assert_run("help_flag", &r);
 }
 
 #[test]
 fn version_flag() {
     let env = Env::new();
-    let r = run(&env, &["--version"]);
+    let r = run_or_skip!(env, ["--version"]);
     assert_run("version_flag", &r);
 }
 
 #[test]
 fn config_show() {
     let env = Env::new();
-    let r = run(&env, &["config"]);
+    let r = run_or_skip!(env, ["config"]);
     assert_run("config_show", &r);
 }
 
 #[test]
 fn ls() {
     let env = Env::new();
-    let r = run(&env, &["ls"]);
+    let r = run_or_skip!(env, ["ls"]);
     assert_run("ls", &r);
 }
 
 #[test]
 fn recent_unlimited() {
     let env = Env::new();
-    let r = run(&env, &["recent"]);
+    let r = run_or_skip!(env, ["recent"]);
     assert_run("recent_unlimited", &r);
 }
 
 #[test]
 fn recent_limit_2() {
     let env = Env::new();
-    let r = run(&env, &["recent", "-n", "2"]);
+    let r = run_or_skip!(env, ["recent", "-n", "2"]);
     assert_run("recent_limit_2", &r);
 }
 
@@ -183,7 +196,7 @@ fn recent_limit_2() {
 #[test]
 fn resolve_exact() {
     let env = Env::new();
-    let r = run(&env, &["resolve", "alpha"]);
+    let r = run_or_skip!(env, ["resolve", "alpha"]);
     assert_run("resolve_exact", &r);
     assert_index("resolve_exact", &env);
 }
@@ -193,21 +206,21 @@ fn resolve_fuzzy_auto() {
     // "alphaa" is a near-prefix match for "alpha" (Jaro-Winkler ≥ 0.85) so
     // resolve should auto-jump and write `Fuzzy match: …` to stderr.
     let env = Env::new();
-    let r = run(&env, &["resolve", "alphaa"]);
+    let r = run_or_skip!(env, ["resolve", "alphaa"]);
     assert_run("resolve_fuzzy_auto", &r);
 }
 
 #[test]
 fn resolve_missing() {
     let env = Env::new();
-    let r = run(&env, &["resolve", "zzz-no-match"]);
+    let r = run_or_skip!(env, ["resolve", "zzz-no-match"]);
     assert_run("resolve_missing", &r);
 }
 
 #[test]
 fn resolve_list() {
     let env = Env::new();
-    let r = run(&env, &["resolve", "--list"]);
+    let r = run_or_skip!(env, ["resolve", "--list"]);
     assert_run("resolve_list", &r);
 }
 
@@ -216,21 +229,21 @@ fn resolve_list() {
 #[test]
 fn shell_init_zsh() {
     let env = Env::new();
-    let r = run(&env, &["shell-init", "zsh"]);
+    let r = run_or_skip!(env, ["shell-init", "zsh"]);
     assert_run("shell_init_zsh", &r);
 }
 
 #[test]
 fn shell_init_bash() {
     let env = Env::new();
-    let r = run(&env, &["shell-init", "bash"]);
+    let r = run_or_skip!(env, ["shell-init", "bash"]);
     assert_run("shell_init_bash", &r);
 }
 
 #[test]
 fn shell_init_fish() {
     let env = Env::new();
-    let r = run(&env, &["shell-init", "fish"]);
+    let r = run_or_skip!(env, ["shell-init", "fish"]);
     assert_run("shell_init_fish", &r);
 }
 
@@ -239,7 +252,7 @@ fn shell_init_fish() {
 #[test]
 fn config_set_editor() {
     let env = Env::new();
-    let r = run(&env, &["config", "set", "editor", "code"]);
+    let r = run_or_skip!(env, ["config", "set", "editor", "code"]);
     assert_run("config_set_editor", &r);
     with_settings!({
         filters => timestamp_filters(),

--- a/crates/gx/tests/snapshots/parity__config_set_editor.config.json.snap
+++ b/crates/gx/tests/snapshots/parity__config_set_editor.config.json.snap
@@ -1,0 +1,13 @@
+---
+source: crates/gx/tests/parity.rs
+expression: env.config_json()
+---
+{
+  "projectDir": "/projects",
+  "defaultHost": "github.com",
+  "defaultOwner": "owner",
+  "structure": "owner",
+  "shallow": false,
+  "similarityThreshold": 0.7,
+  "editor": "code"
+}

--- a/crates/gx/tests/snapshots/parity__config_set_editor.exit.snap
+++ b/crates/gx/tests/snapshots/parity__config_set_editor.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__config_set_editor.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__config_set_editor.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+Set editor = code

--- a/crates/gx/tests/snapshots/parity__config_set_editor.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__config_set_editor.stdout.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+

--- a/crates/gx/tests/snapshots/parity__config_show.exit.snap
+++ b/crates/gx/tests/snapshots/parity__config_show.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__config_show.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__config_show.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__config_show.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__config_show.stdout.snap
@@ -1,0 +1,13 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+{
+  "projectDir": "/projects",
+  "defaultHost": "github.com",
+  "defaultOwner": "owner",
+  "structure": "owner",
+  "shallow": false,
+  "similarityThreshold": 0.7,
+  "editor": "nvim"
+}

--- a/crates/gx/tests/snapshots/parity__help_flag.exit.snap
+++ b/crates/gx/tests/snapshots/parity__help_flag.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__help_flag.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__help_flag.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__help_flag.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__help_flag.stdout.snap
@@ -1,0 +1,38 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+gx v0.2.0 — git project manager
+
+Usage:
+  gx <name>                Jump to project
+  gx clone <repo>          Clone and jump to repo
+  gx open [name]           Open project in editor
+  gx ls                    List indexed projects
+  gx index                 Index new repos (additive scan)
+  gx index <path>...       Add specific repo(s) to index
+  gx rebuild               Rescan and rebuild index
+  gx recent                List recently visited projects
+  gx recent -n <N>         Show last N projects
+  gx resume <name>         Jump to project with git context
+  gx config                Show config
+  gx config set <key> <v>  Set config value
+  gx init                  Scaffold .claude/ agent config
+  gx shell-init [shell]    Print shell integration code
+  gx resolve <name>        Resolve project name to path
+  gx resolve --list        List all project names
+
+Worktrees (requires shell integration):
+  gx <name> wt [args...]   Jump to project and run wt (worktrunk)
+
+Planned (not yet implemented):
+  gx fork <repo>           Fork repo on GitHub, clone, and jump
+  gx fork <repo> --clone-only  Clone existing fork, set upstream
+  gx sync                  Fetch upstream and integrate changes
+  gx sync --rebase|--merge Override sync strategy
+  gx sync --push           Push to origin after syncing
+
+Options:
+  gx open --editor <name>  Override editor for this invocation
+  gx init --type <type>    Override project type detection
+  gx init --force          Overwrite existing CLAUDE.md

--- a/crates/gx/tests/snapshots/parity__ls.exit.snap
+++ b/crates/gx/tests/snapshots/parity__ls.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__ls.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__ls.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__ls.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__ls.stdout.snap
@@ -1,0 +1,8 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+alpha      /projects/owner/alpha
+beta       /projects/owner/beta
+delta-svc  /projects/owner/delta-svc
+gamma      /projects/other/gamma

--- a/crates/gx/tests/snapshots/parity__recent_limit_2.exit.snap
+++ b/crates/gx/tests/snapshots/parity__recent_limit_2.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__recent_limit_2.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__recent_limit_2.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__recent_limit_2.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__recent_limit_2.stdout.snap
@@ -1,0 +1,6 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+delta-svc  /projects/owner/delta-svc  <RELATIVE>
+beta       /projects/owner/beta  <RELATIVE>

--- a/crates/gx/tests/snapshots/parity__recent_unlimited.exit.snap
+++ b/crates/gx/tests/snapshots/parity__recent_unlimited.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__recent_unlimited.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__recent_unlimited.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__recent_unlimited.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__recent_unlimited.stdout.snap
@@ -1,0 +1,8 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+delta-svc  /projects/owner/delta-svc  <RELATIVE>
+beta       /projects/owner/beta  <RELATIVE>
+alpha      /projects/owner/alpha  <RELATIVE>
+gamma      /projects/other/gamma  <RELATIVE>

--- a/crates/gx/tests/snapshots/parity__resolve_exact.exit.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_exact.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__resolve_exact.index.json.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_exact.index.json.snap
@@ -1,0 +1,31 @@
+---
+source: crates/gx/tests/parity.rs
+expression: env.index_json()
+---
+{
+  "projects": {
+    "alpha": {
+      "path": "/projects/owner/alpha",
+      "url": "https://github.com/owner/alpha.git",
+      "clonedAt": "<TIMESTAMP>",
+      "lastVisited": "<TIMESTAMP>"
+    },
+    "beta": {
+      "path": "/projects/owner/beta",
+      "url": "https://github.com/owner/beta.git",
+      "clonedAt": "<TIMESTAMP>",
+      "lastVisited": "<TIMESTAMP>"
+    },
+    "gamma": {
+      "path": "/projects/other/gamma",
+      "url": "git@github.com:other/gamma.git",
+      "clonedAt": "<TIMESTAMP>"
+    },
+    "delta-svc": {
+      "path": "/projects/owner/delta-svc",
+      "url": "https://github.com/owner/delta-svc.git",
+      "clonedAt": "<TIMESTAMP>",
+      "lastVisited": "<TIMESTAMP>"
+    }
+  }
+}

--- a/crates/gx/tests/snapshots/parity__resolve_exact.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_exact.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__resolve_exact.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_exact.stdout.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+/projects/owner/alpha

--- a/crates/gx/tests/snapshots/parity__resolve_fuzzy_auto.exit.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_fuzzy_auto.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__resolve_fuzzy_auto.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_fuzzy_auto.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+Fuzzy match: 'alphaa' -> 'alpha' (97%)

--- a/crates/gx/tests/snapshots/parity__resolve_fuzzy_auto.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_fuzzy_auto.stdout.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+/projects/owner/alpha

--- a/crates/gx/tests/snapshots/parity__resolve_list.exit.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_list.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__resolve_list.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_list.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__resolve_list.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_list.stdout.snap
@@ -1,0 +1,8 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+alpha
+beta
+delta-svc
+gamma

--- a/crates/gx/tests/snapshots/parity__resolve_missing.exit.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_missing.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+1

--- a/crates/gx/tests/snapshots/parity__resolve_missing.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_missing.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+Project 'zzz-no-match' not found

--- a/crates/gx/tests/snapshots/parity__resolve_missing.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__resolve_missing.stdout.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+

--- a/crates/gx/tests/snapshots/parity__shell_init_bash.exit.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_bash.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__shell_init_bash.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_bash.stderr.snap
@@ -1,0 +1,7 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+Warning: compiled gx not found on PATH.
+The generated shell code will use bare `gx` and require it on PATH.
+Run `bun run build` and ensure gx is on your PATH, then re-run `gx shell-init`.

--- a/crates/gx/tests/snapshots/parity__shell_init_bash.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_bash.stdout.snap
@@ -1,0 +1,87 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+# gx — git project manager shell integration
+# Add to ~/.bashrc: eval "$(gx shell-init)"
+
+_GX_BIN="gx"
+
+gx() {
+    case "$1" in
+        clone)
+            local output
+            output=$("$_GX_BIN" clone "${@:2}")
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            fi
+            ;;
+        resume)
+            local output status
+            output=$("$_GX_BIN" resume "${@:2}")
+            status=$?
+            if [ "$status" -ne 0 ]; then
+                return "$status"
+            fi
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            else
+                return 1
+            fi
+            ;;
+        ls|recent|rebuild|config|open|init|index|shell-init|--help|-h|--version|-v)
+            "$_GX_BIN" "$@"
+            ;;
+        resolve)
+            "$_GX_BIN" "$@"
+            ;;
+        "")
+            "$_GX_BIN" --help
+            ;;
+        *)
+            local target
+            target=$("$_GX_BIN" resolve "$1")
+            if [ -n "$target" ] && [ -d "$target" ]; then
+                cd "$target"
+            else
+                return 1
+            fi
+            if [ "$2" = "wt" ]; then
+                if ! command -v wt >/dev/null 2>&1; then
+                    echo "gx: wt (worktrunk) not found on PATH" >&2
+                    echo "Install: brew install worktrunk" >&2
+                    return 1
+                fi
+                shift 2
+                wt "$@"
+            fi
+            ;;
+    esac
+}
+
+# Tab completion
+_gx_completions() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [ "$COMP_CWORD" -eq 1 ]; then
+        local commands="clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v"
+        local projects
+        projects=$("$_GX_BIN" resolve --list 2>/dev/null)
+        COMPREPLY=($(compgen -W "$commands $projects" -- "$cur"))
+    elif [ "$COMP_CWORD" -eq 2 ]; then
+        case "${COMP_WORDS[1]}" in
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|shell-init|--help|--version|-h|-v)
+                if [ "${COMP_WORDS[1]}" = "config" ]; then
+                    COMPREPLY=($(compgen -W "set" -- "$cur"))
+                fi
+                ;;
+            *)
+                COMPREPLY=($(compgen -W "wt" -- "$cur"))
+                ;;
+        esac
+    elif [ "$COMP_CWORD" -eq 3 ] && [ "${COMP_WORDS[1]}" = "config" ] && [ "$prev" = "set" ]; then
+        COMPREPLY=($(compgen -W "projectDir defaultHost structure shallow similarityThreshold editor" -- "$cur"))
+    fi
+}
+complete -F _gx_completions gx

--- a/crates/gx/tests/snapshots/parity__shell_init_fish.exit.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_fish.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__shell_init_fish.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_fish.stderr.snap
@@ -1,0 +1,7 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+Warning: compiled gx not found on PATH.
+The generated shell code will use bare `gx` and require it on PATH.
+Run `bun run build` and ensure gx is on your PATH, then re-run `gx shell-init`.

--- a/crates/gx/tests/snapshots/parity__shell_init_fish.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_fish.stdout.snap
@@ -1,0 +1,56 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+# gx — git project manager shell integration
+# Add to ~/.config/fish/conf.d/gx.fish: gx shell-init | source
+
+set -g _GX_BIN "gx"
+
+function gx
+    switch $argv[1]
+        case clone
+            set -l output ($_GX_BIN clone $argv[2..])
+            if test -n "$output" -a -d "$output"
+                cd "$output"
+            end
+        case resume
+            set -l output ($_GX_BIN resume $argv[2..])
+            set -l cmd_status $status
+            if test $cmd_status -ne 0
+                return $cmd_status
+            end
+            if test -n "$output" -a -d "$output"
+                cd "$output"
+            else
+                return 1
+            end
+        case ls recent rebuild config open init index shell-init --help -h --version -v resolve
+            $_GX_BIN $argv
+        case ''
+            $_GX_BIN --help
+        case '*'
+            set -l target ($_GX_BIN resolve $argv[1])
+            if test -n "$target" -a -d "$target"
+                cd "$target"
+            else
+                return 1
+            end
+            if test "$argv[2]" = "wt"
+                if not command -v wt >/dev/null 2>&1
+                    echo "gx: wt (worktrunk) not found on PATH" >&2
+                    echo "Install: brew install worktrunk" >&2
+                    return 1
+                end
+                wt $argv[3..]
+            end
+    end
+end
+
+# Tab completion
+complete -c gx -f
+complete -c gx -n "__fish_use_subcommand" -a "clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v"
+complete -c gx -n "__fish_use_subcommand" -a "($_GX_BIN resolve --list 2>/dev/null)"
+complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
+complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"
+complete -c gx -n "not __fish_seen_subcommand_from clone ls recent resume rebuild config resolve open init index shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt"

--- a/crates/gx/tests/snapshots/parity__shell_init_zsh.exit.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_zsh.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__shell_init_zsh.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_zsh.stderr.snap
@@ -1,0 +1,7 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+Warning: compiled gx not found on PATH.
+The generated shell code will use bare `gx` and require it on PATH.
+Run `bun run build` and ensure gx is on your PATH, then re-run `gx shell-init`.

--- a/crates/gx/tests/snapshots/parity__shell_init_zsh.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__shell_init_zsh.stdout.snap
@@ -1,0 +1,85 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+# gx — git project manager shell integration
+# Add to ~/.zshrc: eval "$(gx shell-init)"
+
+_GX_BIN="gx"
+
+gx() {
+    case "$1" in
+        clone)
+            local output
+            output=$("$_GX_BIN" clone "${@:2}")
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            fi
+            ;;
+        resume)
+            local output
+            output=$("$_GX_BIN" resume "${@:2}")
+            local status=$?
+            if [ "$status" -ne 0 ]; then
+                return "$status"
+            fi
+            if [ -n "$output" ] && [ -d "$output" ]; then
+                cd "$output"
+            else
+                return 1
+            fi
+            ;;
+        ls|recent|rebuild|config|open|init|index|shell-init|--help|-h|--version|-v)
+            "$_GX_BIN" "$@"
+            ;;
+        resolve)
+            "$_GX_BIN" "$@"
+            ;;
+        "")
+            "$_GX_BIN" --help
+            ;;
+        *)
+            local target
+            target=$("$_GX_BIN" resolve "$1")
+            if [ -n "$target" ] && [ -d "$target" ]; then
+                cd "$target"
+            else
+                return 1
+            fi
+            if [ "$2" = "wt" ]; then
+                if ! command -v wt >/dev/null 2>&1; then
+                    echo "gx: wt (worktrunk) not found on PATH" >&2
+                    echo "Install: brew install worktrunk" >&2
+                    return 1
+                fi
+                shift 2
+                wt "$@"
+            fi
+            ;;
+    esac
+}
+
+# Tab completion
+_gx() {
+    local -a commands projects
+    commands=(clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v)
+
+    if (( CURRENT == 2 )); then
+        projects=($("$_GX_BIN" resolve --list 2>/dev/null))
+        compadd "${commands[@]}" "${projects[@]}"
+    elif (( CURRENT == 3 )); then
+        case "${words[2]}" in
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|shell-init|--help|--version|-h|-v)
+                if [[ "${words[2]}" == "config" ]]; then
+                    compadd set
+                fi
+                ;;
+            *)
+                compadd wt
+                ;;
+        esac
+    elif (( CURRENT == 4 )) && [[ "${words[2]}" == "config" ]] && [[ "${words[3]}" == "set" ]]; then
+        compadd projectDir defaultHost structure shallow similarityThreshold editor
+    fi
+}
+(( $+functions[compdef] )) && compdef _gx gx

--- a/crates/gx/tests/snapshots/parity__version_flag.exit.snap
+++ b/crates/gx/tests/snapshots/parity__version_flag.exit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.code.to_string()
+---
+0

--- a/crates/gx/tests/snapshots/parity__version_flag.stderr.snap
+++ b/crates/gx/tests/snapshots/parity__version_flag.stderr.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stderr
+---
+

--- a/crates/gx/tests/snapshots/parity__version_flag.stdout.snap
+++ b/crates/gx/tests/snapshots/parity__version_flag.stdout.snap
@@ -1,0 +1,5 @@
+---
+source: crates/gx/tests/parity.rs
+expression: run.stdout
+---
+gx v0.2.0


### PR DESCRIPTION
Adds an empty Rust workspace with a single crate at crates/gx/ that
compiles to a stub binary, plus a parallel Rust CI job (ubuntu-latest,
macos-latest) running fmt, clippy -D warnings, test, and release
build. TS build path is untouched.

This is the reversible foundation for the Rust port (RST module). The
stub binary lets RST-2's snapshot harness anchor against a working
cargo workspace before any logic is ported.

Local release binary is 332K with no dependencies declared — orders
of magnitude smaller than the current bun --compile artifact.