### PR TITLE
chore(rust): cargo fmt + mark RST-1 complete in APS plan

### DIFF
--- a/crates/gx/src/config.rs
+++ b/crates/gx/src/config.rs
@@ -183,8 +183,13 @@ pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> GxResult<()> {
         f.write_all(contents)
             .map_err(|e| GxError::Other(format!("write {}: {e}", tmp.display())))?;
     }
-    fs::rename(&tmp, path)
-        .map_err(|e| GxError::Other(format!("rename {} -> {}: {e}", tmp.display(), path.display())))
+    fs::rename(&tmp, path).map_err(|e| {
+        GxError::Other(format!(
+            "rename {} -> {}: {e}",
+            tmp.display(),
+            path.display()
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -208,12 +213,18 @@ mod tests {
 
     #[test]
     fn expand_tilde_absolute_unchanged() {
-        assert_eq!(expand_tilde("/usr/local/bin"), PathBuf::from("/usr/local/bin"));
+        assert_eq!(
+            expand_tilde("/usr/local/bin"),
+            PathBuf::from("/usr/local/bin")
+        );
     }
 
     #[test]
     fn expand_tilde_relative_unchanged() {
-        assert_eq!(expand_tilde("relative/path"), PathBuf::from("relative/path"));
+        assert_eq!(
+            expand_tilde("relative/path"),
+            PathBuf::from("relative/path")
+        );
     }
 
     // --- validate_agent ---------------------------------------------------
@@ -225,12 +236,18 @@ mod tests {
 
     #[test]
     fn agent_lowercased() {
-        assert_eq!(validate_agent(Some("Morgan")).unwrap(), Some("morgan".into()));
+        assert_eq!(
+            validate_agent(Some("Morgan")).unwrap(),
+            Some("morgan".into())
+        );
     }
 
     #[test]
     fn agent_trimmed() {
-        assert_eq!(validate_agent(Some("  morgan  ")).unwrap(), Some("morgan".into()));
+        assert_eq!(
+            validate_agent(Some("  morgan  ")).unwrap(),
+            Some("morgan".into())
+        );
     }
 
     #[test]

--- a/crates/gx/src/fuzzy.rs
+++ b/crates/gx/src/fuzzy.rs
@@ -99,7 +99,11 @@ pub fn fuzzy_match(query: &str, entries: &[FuzzyEntry], threshold: f64) -> Vec<F
         })
         .filter(|r| r.score >= threshold)
         .collect();
-    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     results
 }
 

--- a/crates/gx/src/index_store.rs
+++ b/crates/gx/src/index_store.rs
@@ -11,7 +11,14 @@ use crate::types::{Index, IndexEntry};
 const MAX_SCAN_DEPTH: usize = 10;
 
 fn skip_dirs() -> &'static [&'static str] {
-    &["node_modules", "vendor", "target", ".build", "dist", "build"]
+    &[
+        "node_modules",
+        "vendor",
+        "target",
+        ".build",
+        "dist",
+        "build",
+    ]
 }
 
 /// In-memory view of `~/.config/gx/index.json` with the same surface as the
@@ -94,8 +101,14 @@ impl ProjectIndex {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         entries.sort_by(|a, b| {
-            let ta = a.1.last_visited.as_deref().unwrap_or(a.1.cloned_at.as_str());
-            let tb = b.1.last_visited.as_deref().unwrap_or(b.1.cloned_at.as_str());
+            let ta =
+                a.1.last_visited
+                    .as_deref()
+                    .unwrap_or(a.1.cloned_at.as_str());
+            let tb =
+                b.1.last_visited
+                    .as_deref()
+                    .unwrap_or(b.1.cloned_at.as_str());
             tb.cmp(ta)
         });
         if let Some(n) = limit {
@@ -339,10 +352,7 @@ mod tests {
                 last_visited: None,
             },
         );
-        assert_eq!(
-            idx.resolve("gx"),
-            Some("/home/user/src/joshuaboys/gx")
-        );
+        assert_eq!(idx.resolve("gx"), Some("/home/user/src/joshuaboys/gx"));
     }
 
     #[test]
@@ -585,10 +595,7 @@ mod tests {
 
         let mut idx = ProjectIndex::default();
         idx.add("external", entry("/other/dir/external"));
-        idx.add(
-            "repoA",
-            entry(a.to_string_lossy().as_ref()),
-        );
+        idx.add("repoA", entry(a.to_string_lossy().as_ref()));
 
         idx.scoped_rebuild(tmp.path()).unwrap();
 
@@ -605,14 +612,8 @@ mod tests {
         let user_repo = make_repo(tmp.path(), "org/userrepo");
 
         let mut idx = ProjectIndex::default();
-        idx.add(
-            "agentrepo",
-            entry(agent_repo.to_string_lossy().as_ref()),
-        );
-        idx.add(
-            "userrepo",
-            entry(user_repo.to_string_lossy().as_ref()),
-        );
+        idx.add("agentrepo", entry(agent_repo.to_string_lossy().as_ref()));
+        idx.add("userrepo", entry(user_repo.to_string_lossy().as_ref()));
 
         idx.scoped_rebuild(tmp.path()).unwrap();
 
@@ -633,14 +634,8 @@ mod tests {
         let user_repo = make_repo(tmp.path(), "org/userrepo");
 
         let mut idx = ProjectIndex::default();
-        idx.add(
-            "agentrepo",
-            entry(agent_repo.to_string_lossy().as_ref()),
-        );
-        idx.add(
-            "userrepo",
-            entry(user_repo.to_string_lossy().as_ref()),
-        );
+        idx.add("agentrepo", entry(agent_repo.to_string_lossy().as_ref()));
+        idx.add("userrepo", entry(user_repo.to_string_lossy().as_ref()));
 
         idx.scoped_rebuild(&agent_dir).unwrap();
 

--- a/crates/gx/src/path.rs
+++ b/crates/gx/src/path.rs
@@ -8,7 +8,10 @@ use crate::types::{Config, ParsedRepo, Structure};
 pub fn to_path_for(parsed: &ParsedRepo, config: &Config, agent: Option<&str>) -> PathBuf {
     let base = effective_project_dir_for(config, agent);
     match config.structure {
-        Structure::Host => base.join(&parsed.host).join(&parsed.owner).join(&parsed.repo),
+        Structure::Host => base
+            .join(&parsed.host)
+            .join(&parsed.owner)
+            .join(&parsed.repo),
         Structure::Flat => base.join(&parsed.repo),
         Structure::Owner => base.join(&parsed.owner).join(&parsed.repo),
     }

--- a/crates/gx/src/templates.rs
+++ b/crates/gx/src/templates.rs
@@ -136,7 +136,8 @@ Include:
 4. Potential edge cases
 ";
 
-const REVIEW_COMMAND: &str = "Review the following code changes for bugs, style issues, and improvements:
+const REVIEW_COMMAND: &str =
+    "Review the following code changes for bugs, style issues, and improvements:
 
 $ARGUMENTS
 

--- a/crates/gx/src/time.rs
+++ b/crates/gx/src/time.rs
@@ -133,10 +133,7 @@ fn parse_iso_ms(iso: &str) -> Option<i64> {
     }
 
     let days = days_from_civil(year, month as i64, day as i64);
-    let seconds_utc = days * 86_400
-        + (hour as i64) * 3600
-        + (minute as i64) * 60
-        + second as i64
+    let seconds_utc = days * 86_400 + (hour as i64) * 3600 + (minute as i64) * 60 + second as i64
         - tz_offset_minutes * 60;
     Some(seconds_utc * 1000 + frac_ms)
 }

--- a/crates/gx/src/url.rs
+++ b/crates/gx/src/url.rs
@@ -131,7 +131,10 @@ pub fn to_clone_url(parsed: &ParsedRepo) -> String {
     if parsed.original_url.starts_with("git@") || parsed.original_url.starts_with("ssh://") {
         parsed.original_url.clone()
     } else {
-        format!("https://{}/{}/{}.git", parsed.host, parsed.owner, parsed.repo)
+        format!(
+            "https://{}/{}/{}.git",
+            parsed.host, parsed.owner, parsed.repo
+        )
     }
 }
 

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -83,7 +83,7 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 | [Index Reliability & Observability](./modules/17-index-observability.aps.md)              | Index diagnostics, stats, and scan telemetry                                                  | Draft               | v5      | Index, Tracking          |
 | [APS Runtime Provisioning & Project Config](./modules/18-aps-runtime-provisioning.aps.md) | Global APS runtime with per-project policy via `.apsrc.yaml` and init-time preference capture | Ready               | v6      | CLI, APS scaffolding     |
 | [Fork & Sync](./modules/19-fork.aps.md)                                                   | Fork repos via GitHub, clone locally, and keep forks synced with upstream                     | Draft               | v4      | Clone, Shell Plugin, CLI |
-| [Rust Port](./modules/20-rust-port.aps.md)                                                | Re-implement gx as a Rust binary with full behavior parity                                    | Draft               | v5      | All                      |
+| [Rust Port](./modules/20-rust-port.aps.md)                                                | Re-implement gx as a Rust binary with full behavior parity                                    | Committed           | v5      | All                      |
 
 ## Risks
 

--- a/plans/modules/20-rust-port.aps.md
+++ b/plans/modules/20-rust-port.aps.md
@@ -1,8 +1,8 @@
 # Rust Port
 
-| ID  | Owner       | Status |
-| --- | ----------- | ------ |
-| RST | @joshuaboys | Draft  |
+| ID  | Owner       | Status    |
+| --- | ----------- | --------- |
+| RST | @joshuaboys | Committed |
 
 ## Purpose
 
@@ -65,7 +65,7 @@ Change status to **Ready** when:
 
 ## Work Items
 
-- [ ] **RST-1:** Cargo scaffolding and CI matrix
+- [x] **RST-1:** Cargo scaffolding and CI matrix
   - Cargo manifest, empty binary, `cargo {fmt,clippy,test,build}` jobs added to `ci.yml`
 - [x] **RST-2:** Snapshot harness against the current TS binary
   - Harness in `crates/gx/tests/snapshots.rs` runs the binary under test in an


### PR DESCRIPTION
## Summary

- Fixed `cargo fmt` drift across the Rust port crate (`crates/gx/src`).
- Marked **RST-1** (Cargo scaffolding and CI matrix) complete in the APS plan.
- Set Rust Port module status to **Committed** per planning workflow.
- Unblocks the dedicated `rust:` CI job in `.github/workflows/ci.yml`.

## Changes

- Ran `cargo fmt` (7 source files in `crates/gx/src`).
- Updated `plans/modules/20-rust-port.aps.md` (RST-1 checkbox + module status).
- Synced `plans/index.aps.md`.

## Test Plan

- [x] `cargo fmt --check` → clean (green)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` → clean
- [x] `cargo test --workspace` → all pass (136 unit + snapshot harness ignored as designed)
- [x] `cargo build --release --workspace` → succeeds
- [x] No unrelated files committed (Claude logs excluded)

## Related

- APS plan: `plans/modules/20-rust-port.aps.md` (RST-1)
- Decision: `plans/decisions/010-rust-port.md`
- Part of Rust port effort (D-010)