### PR TITLE
feat: add gx doctor health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Clone, jump, and organise repos from the terminal.**
 - **Shell integration** — tab completion and auto-`cd` for zsh, bash, and fish
 - **Open in any editor** — `gx open` launches VS Code, nvim, or whatever you use
 - **AI agent scaffolding** — `gx init` generates `.claude/` configs tailored to your project's language
+- **Installation health checks** — `gx doctor` verifies the binary, shell integration, config, and index
 - **Single binary** — zero runtime dependencies, compiled from Rust
 
 ## Quick Start
@@ -147,6 +148,14 @@ gx rebuild
 ```
 
 Rescans the project directory and rebuilds the project index.
+
+### Check installation health
+
+```sh
+gx doctor
+```
+
+Reports whether the `gx` binary is on `PATH`, shell integration is configured, config/index paths exist, and indexed projects point at existing directories.
 
 ## Configuration
 

--- a/crates/gx/src/cli.rs
+++ b/crates/gx/src/cli.rs
@@ -9,7 +9,8 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use crate::commands::{
-    clone, config_cmd, index_repos, init, ls, open, rebuild, recent, resolve, resume, shell_init,
+    clone, config_cmd, doctor, index_repos, init, ls, open, rebuild, recent, resolve, resume,
+    shell_init,
 };
 use crate::config::{get_agent, get_config_path, load_config};
 use crate::errors::{GxError, GxResult};
@@ -39,6 +40,7 @@ Usage:
   gx recent                List recently visited projects
   gx recent -n <N>         Show last N projects
   gx resume <name>         Jump to project with git context
+  gx doctor                Verify installation health
   gx config                Show config
   gx config set <key> <v>  Set config value
   gx init                  Scaffold .claude/ agent config
@@ -164,6 +166,7 @@ fn dispatch(args: &[String]) -> GxResult<()> {
             };
             resume::resume(name, &index_path, &config)
         }
+        "doctor" => doctor::doctor(&config_path, &index_path, &config),
         "ls" => {
             ls::ls(&index_path);
             Ok(())

--- a/crates/gx/src/commands.rs
+++ b/crates/gx/src/commands.rs
@@ -3,6 +3,7 @@
 
 pub mod clone;
 pub mod config_cmd;
+pub mod doctor;
 pub mod index_repos;
 pub mod init;
 pub mod ls;

--- a/crates/gx/src/commands/doctor.rs
+++ b/crates/gx/src/commands/doctor.rs
@@ -108,12 +108,42 @@ fn shell_check() -> Check {
 
 pub fn doctor(config_path: &Path, index_path: &Path, config: &Config) -> GxResult<()> {
     let project_dir = effective_project_dir(config)?;
-    let idx = ProjectIndex::load(index_path);
-    let entries = idx.list();
-    let stale = entries
-        .iter()
-        .filter(|(_, entry)| !Path::new(&entry.path).exists())
-        .count();
+    let index_check = if !index_path.exists() {
+        Check {
+            name: "index",
+            status: "warn",
+            message: format!("missing; run gx rebuild ({})", index_path.display()),
+        }
+    } else {
+        match ProjectIndex::try_load(index_path) {
+            Ok(idx) => {
+                let entries = idx.list();
+                let stale = entries
+                    .iter()
+                    .filter(|(_, entry)| !Path::new(&entry.path).exists())
+                    .count();
+                Check {
+                    name: "index",
+                    status: if stale == 0 { "ok" } else { "warn" },
+                    message: if stale == 0 {
+                        format!("{} project(s), {}", entries.len(), index_path.display())
+                    } else {
+                        format!(
+                            "{} project(s), {} stale path(s), {}",
+                            entries.len(),
+                            stale,
+                            index_path.display()
+                        )
+                    },
+                }
+            }
+            Err(err) => Check {
+                name: "index",
+                status: "warn",
+                message: format!("{err}; run gx rebuild ({})", index_path.display()),
+            },
+        }
+    };
 
     let mut checks = vec![
         Check {
@@ -159,28 +189,7 @@ pub fn doctor(config_path: &Path, index_path: &Path, config: &Config) -> GxResul
                 message: format!("missing: {}", project_dir.display()),
             }
         },
-        if index_path.exists() {
-            Check {
-                name: "index",
-                status: if stale == 0 { "ok" } else { "warn" },
-                message: if stale == 0 {
-                    format!("{} project(s), {}", entries.len(), index_path.display())
-                } else {
-                    format!(
-                        "{} project(s), {} stale path(s), {}",
-                        entries.len(),
-                        stale,
-                        index_path.display()
-                    )
-                },
-            }
-        } else {
-            Check {
-                name: "index",
-                status: "warn",
-                message: format!("missing; run gx rebuild ({})", index_path.display()),
-            }
-        },
+        index_check,
         shell_check(),
     ];
 

--- a/crates/gx/src/commands/doctor.rs
+++ b/crates/gx/src/commands/doctor.rs
@@ -1,0 +1,217 @@
+//! `gx doctor` — read-only installation health checks.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::config::effective_project_dir;
+use crate::errors::GxResult;
+use crate::index_store::ProjectIndex;
+use crate::types::Config;
+
+struct Check {
+    name: &'static str,
+    status: &'static str,
+    message: String,
+}
+
+fn binary_on_path() -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    for dir in env::split_paths(&path) {
+        let candidate = dir.join("gx");
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    match fs::metadata(path) {
+        Ok(meta) if meta.is_file() => meta.permissions().mode() & 0o111 != 0,
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn shell_rc_files(shell_path: &str) -> Vec<PathBuf> {
+    let Some(home) = env::var_os("HOME").map(PathBuf::from) else {
+        return Vec::new();
+    };
+    let shell = Path::new(shell_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(shell_path);
+
+    match shell {
+        "zsh" => vec![home.join(".zshrc")],
+        "bash" => {
+            if cfg!(target_os = "macos") {
+                vec![
+                    home.join(".bash_profile"),
+                    home.join(".profile"),
+                    home.join(".bashrc"),
+                ]
+            } else {
+                vec![home.join(".bashrc")]
+            }
+        }
+        "fish" => vec![home.join(".config/fish/conf.d/gx.fish")],
+        _ => Vec::new(),
+    }
+}
+
+fn shell_check() -> Check {
+    let shell = env::var("GX_SHELL_OVERRIDE")
+        .or_else(|_| env::var("SHELL"))
+        .unwrap_or_default();
+    let rc_files = shell_rc_files(&shell);
+
+    if rc_files.is_empty() {
+        return Check {
+            name: "shell",
+            status: "warn",
+            message: "unsupported shell; run gx shell-init <zsh|bash|fish>".to_string(),
+        };
+    }
+
+    for rc in &rc_files {
+        if let Ok(text) = fs::read_to_string(rc) {
+            if text.contains("gx shell-init") || text.contains("gx.plugin.zsh") {
+                return Check {
+                    name: "shell",
+                    status: "ok",
+                    message: format!("integration found in {}", rc.display()),
+                };
+            }
+        }
+    }
+
+    let candidates = rc_files
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Check {
+        name: "shell",
+        status: "warn",
+        message: format!("integration not found in {candidates}; run gx shell-init"),
+    }
+}
+
+pub fn doctor(config_path: &Path, index_path: &Path, config: &Config) -> GxResult<()> {
+    let project_dir = effective_project_dir(config)?;
+    let idx = ProjectIndex::load(index_path);
+    let entries = idx.list();
+    let stale = entries
+        .iter()
+        .filter(|(_, entry)| !Path::new(&entry.path).exists())
+        .count();
+
+    let mut checks = vec![
+        Check {
+            name: "runtime",
+            status: "ok",
+            message: "native".to_string(),
+        },
+        match binary_on_path() {
+            Some(path) => Check {
+                name: "binary",
+                status: "ok",
+                message: format!("gx found at {}", path.display()),
+            },
+            None => Check {
+                name: "binary",
+                status: "warn",
+                message: "gx is not on PATH".to_string(),
+            },
+        },
+        if config_path.exists() {
+            Check {
+                name: "config",
+                status: "ok",
+                message: config_path.display().to_string(),
+            }
+        } else {
+            Check {
+                name: "config",
+                status: "warn",
+                message: format!("missing; defaults are in use ({})", config_path.display()),
+            }
+        },
+        if project_dir.exists() {
+            Check {
+                name: "projectDir",
+                status: "ok",
+                message: project_dir.display().to_string(),
+            }
+        } else {
+            Check {
+                name: "projectDir",
+                status: "warn",
+                message: format!("missing: {}", project_dir.display()),
+            }
+        },
+        if index_path.exists() {
+            Check {
+                name: "index",
+                status: if stale == 0 { "ok" } else { "warn" },
+                message: if stale == 0 {
+                    format!("{} project(s), {}", entries.len(), index_path.display())
+                } else {
+                    format!(
+                        "{} project(s), {} stale path(s), {}",
+                        entries.len(),
+                        stale,
+                        index_path.display()
+                    )
+                },
+            }
+        } else {
+            Check {
+                name: "index",
+                status: "warn",
+                message: format!("missing; run gx rebuild ({})", index_path.display()),
+            }
+        },
+        shell_check(),
+    ];
+
+    if let Some(parent) = config_path.parent() {
+        if !parent.exists() {
+            checks.push(Check {
+                name: "configDir",
+                status: "warn",
+                message: format!("missing: {}", parent.display()),
+            });
+        }
+    }
+
+    let width = checks
+        .iter()
+        .map(|check| check.name.len())
+        .max()
+        .unwrap_or(0);
+    for check in &checks {
+        println!(
+            "{:<width$}  {:<4}  {}",
+            check.name, check.status, check.message
+        );
+    }
+
+    let warnings = checks.iter().filter(|check| check.status == "warn").count();
+    if warnings == 0 {
+        println!("doctor: ok");
+    } else {
+        println!("doctor: {warnings} warning(s); gx can still run");
+    }
+
+    Ok(())
+}

--- a/crates/gx/src/commands/shell_init.rs
+++ b/crates/gx/src/commands/shell_init.rs
@@ -1,7 +1,8 @@
 //! `gx shell-init [shell]` — print shell integration code. Ported from
-//! `src/commands/shell-init.ts`. The emitted code is byte-identical to the TS
-//! output (the snapshot harness enforces this); the only environment-specific
-//! token is `_GX_BIN`, which the shell wrappers use to invoke the binary.
+//! the TS `src/commands/shell-init.ts` and since extended (e.g. `doctor`
+//! pass-through); the snapshot harness pins the exact output. The only
+//! environment-specific token is `_GX_BIN`, which the shell wrappers use to
+//! invoke the binary.
 
 use crate::errors::{GxError, GxResult};
 
@@ -111,7 +112,7 @@ gx() {
                 return 1
             fi
             ;;
-        ls|recent|rebuild|config|open|init|index|shell-init|--help|-h|--version|-v)
+        ls|recent|rebuild|config|open|init|index|doctor|shell-init|--help|-h|--version|-v)
             "$_GX_BIN" "$@"
             ;;
         resolve)
@@ -144,14 +145,14 @@ gx() {
 # Tab completion
 _gx() {
     local -a commands projects
-    commands=(clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v)
+    commands=(clone ls recent resume rebuild config resolve open init index doctor shell-init --help --version -h -v)
 
     if (( CURRENT == 2 )); then
         projects=($("$_GX_BIN" resolve --list 2>/dev/null))
         compadd "${commands[@]}" "${projects[@]}"
     elif (( CURRENT == 3 )); then
         case "${words[2]}" in
-            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|shell-init|--help|--version|-h|-v)
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|doctor|shell-init|--help|--version|-h|-v)
                 if [[ "${words[2]}" == "config" ]]; then
                     compadd set
                 fi
@@ -193,7 +194,7 @@ gx() {
                 return 1
             fi
             ;;
-        ls|recent|rebuild|config|open|init|index|shell-init|--help|-h|--version|-v)
+        ls|recent|rebuild|config|open|init|index|doctor|shell-init|--help|-h|--version|-v)
             "$_GX_BIN" "$@"
             ;;
         resolve)
@@ -229,13 +230,13 @@ _gx_completions() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     if [ "$COMP_CWORD" -eq 1 ]; then
-        local commands="clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v"
+        local commands="clone ls recent resume rebuild config resolve open init index doctor shell-init --help --version -h -v"
         local projects
         projects=$("$_GX_BIN" resolve --list 2>/dev/null)
         COMPREPLY=($(compgen -W "$commands $projects" -- "$cur"))
     elif [ "$COMP_CWORD" -eq 2 ]; then
         case "${COMP_WORDS[1]}" in
-            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|shell-init|--help|--version|-h|-v)
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|doctor|shell-init|--help|--version|-h|-v)
                 if [ "${COMP_WORDS[1]}" = "config" ]; then
                     COMPREPLY=($(compgen -W "set" -- "$cur"))
                 fi
@@ -273,7 +274,7 @@ function gx
             else
                 return 1
             end
-        case ls recent rebuild config open init index shell-init --help -h --version -v resolve
+        case ls recent rebuild config open init index doctor shell-init --help -h --version -v resolve
             $_GX_BIN $argv
         case ''
             $_GX_BIN --help
@@ -297,8 +298,8 @@ end
 
 # Tab completion
 complete -c gx -f
-complete -c gx -n "__fish_use_subcommand" -a "clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v"
+complete -c gx -n "__fish_use_subcommand" -a "clone ls recent resume rebuild config resolve open init index doctor shell-init --help --version -h -v"
 complete -c gx -n "__fish_use_subcommand" -a "($_GX_BIN resolve --list 2>/dev/null)"
 complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
 complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"
-complete -c gx -n "not __fish_seen_subcommand_from clone ls recent resume rebuild config resolve open init index shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt""##;
+complete -c gx -n "not __fish_seen_subcommand_from clone ls recent resume rebuild config resolve open init index doctor shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt""##;

--- a/crates/gx/src/index_store.rs
+++ b/crates/gx/src/index_store.rs
@@ -33,13 +33,21 @@ impl ProjectIndex {
     /// Load the index from `path`. Missing file, unreadable file, or invalid
     /// JSON all yield an empty index (matching the TS fall-back).
     pub fn load(path: &Path) -> Self {
-        let Ok(raw) = fs::read_to_string(path) else {
-            return Self::default();
-        };
-        match serde_json::from_str::<Index>(&raw) {
-            Ok(data) => ProjectIndex { data },
-            Err(_) => Self::default(),
+        Self::try_load(path).unwrap_or_default()
+    }
+
+    /// Like `load`, but an existing file that cannot be read or parsed is an
+    /// error instead of a silent empty index. A missing file still yields an
+    /// empty index. Used by `gx doctor` to surface index corruption.
+    pub fn try_load(path: &Path) -> GxResult<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
         }
+        let raw = fs::read_to_string(path)
+            .map_err(|e| GxError::command(format!("unreadable index file: {e}")))?;
+        let data = serde_json::from_str::<Index>(&raw)
+            .map_err(|e| GxError::command(format!("invalid index JSON: {e}")))?;
+        Ok(ProjectIndex { data })
     }
 
     /// Insert `entry` under `name`, overwriting any existing entry (with a
@@ -339,6 +347,23 @@ mod tests {
         let idx = ProjectIndex::load(&tmp.path().join("index.json"));
         assert!(idx.is_empty());
         assert!(idx.list().is_empty());
+    }
+
+    #[test]
+    fn try_load_invalid_json_errors_but_load_falls_back_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("index.json");
+        fs::write(&path, "{not valid json").unwrap();
+        let err = ProjectIndex::try_load(&path).unwrap_err();
+        assert!(err.to_string().contains("invalid index JSON"));
+        assert!(ProjectIndex::load(&path).is_empty());
+    }
+
+    #[test]
+    fn try_load_missing_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let idx = ProjectIndex::try_load(&tmp.path().join("index.json")).unwrap();
+        assert!(idx.is_empty());
     }
 
     #[test]

--- a/crates/gx/tests/snapshots.rs
+++ b/crates/gx/tests/snapshots.rs
@@ -111,6 +111,11 @@ fn assert_snapshot(name: &str, value: &str) {
     // Resolved binary path leaks into `gx shell-init` as `_GX_BIN="..."`.
     settings.add_filter(r#"_GX_BIN="[^"]*""#, r#"_GX_BIN="<BIN>""#);
     settings.add_filter(r#"set -g _GX_BIN "[^"]*""#, r#"set -g _GX_BIN "<BIN>""#);
+    // `gx doctor` reports paths under the isolated HOME TempDir. TempDir uses
+    // platform-specific roots, so normalize both Linux and macOS forms.
+    settings.add_filter(r"/tmp/\.tmp[A-Za-z0-9]+", "<HOME>");
+    settings.add_filter(r"/var/folders/[^\s,)]*/\.tmp[A-Za-z0-9]+", "<HOME>");
+    settings.add_filter(r"/private/var/folders/[^\s,)]*/\.tmp[A-Za-z0-9]+", "<HOME>");
     // `gx recent` prints relative times against Date.now(); normalize.
     settings.add_filter(r"\d+ (minute|hour|day|week|month)s? ago", "<TIME_AGO>");
     settings.add_filter(r"just now", "<TIME_AGO>");
@@ -321,6 +326,17 @@ fn snapshot_resume_missing() {
         c
     });
     assert_snapshot("resume_missing", &format_capture(&cap));
+}
+
+#[test]
+fn snapshot_doctor_missing_paths() {
+    let h = Harness::new();
+    let cap = run({
+        let mut c = h.command();
+        c.arg("doctor").env("PATH", "");
+        c
+    });
+    assert_snapshot("doctor_missing_paths", &format_capture(&cap));
 }
 
 #[test]

--- a/crates/gx/tests/snapshots.rs
+++ b/crates/gx/tests/snapshots.rs
@@ -340,6 +340,22 @@ fn snapshot_doctor_missing_paths() {
 }
 
 #[test]
+fn snapshot_doctor_corrupt_index() {
+    let h = Harness::new();
+    fs::write(
+        h.home.path().join(".config/gx/index.json"),
+        "{not valid json",
+    )
+    .expect("write corrupt index");
+    let cap = run({
+        let mut c = h.command();
+        c.arg("doctor").env("PATH", "");
+        c
+    });
+    assert_snapshot("doctor_corrupt_index", &format_capture(&cap));
+}
+
+#[test]
 fn snapshot_open_missing() {
     let h = Harness::new().with_fixture_index();
     let cap = run({

--- a/crates/gx/tests/snapshots/doctor_corrupt_index.snap
+++ b/crates/gx/tests/snapshots/doctor_corrupt_index.snap
@@ -1,0 +1,14 @@
+---
+source: crates/gx/tests/snapshots.rs
+---
+exit: 0
+---- stdout ----
+runtime     ok    native
+binary      warn  gx is not on PATH
+config      warn  missing; defaults are in use (<HOME>/.config/gx/config.json)
+projectDir  warn  missing: <HOME>/Projects/src
+index       warn  invalid index JSON: key must be a string at line 1 column 2; run gx rebuild (<HOME>/.config/gx/index.json)
+shell       warn  integration not found in <HOME>/.zshrc; run gx shell-init
+doctor: 5 warning(s); gx can still run
+
+---- stderr ----

--- a/crates/gx/tests/snapshots/doctor_missing_paths.snap
+++ b/crates/gx/tests/snapshots/doctor_missing_paths.snap
@@ -1,0 +1,14 @@
+---
+source: crates/gx/tests/snapshots.rs
+---
+exit: 0
+---- stdout ----
+runtime     ok    native
+binary      warn  gx is not on PATH
+config      warn  missing; defaults are in use (<HOME>/.config/gx/config.json)
+projectDir  warn  missing: <HOME>/Projects/src
+index       warn  missing; run gx rebuild (<HOME>/.config/gx/index.json)
+shell       warn  integration not found in <HOME>/.zshrc; run gx shell-init
+doctor: 5 warning(s); gx can still run
+
+---- stderr ----

--- a/crates/gx/tests/snapshots/help.snap
+++ b/crates/gx/tests/snapshots/help.snap
@@ -16,6 +16,7 @@ Usage:
   gx recent                List recently visited projects
   gx recent -n <N>         Show last N projects
   gx resume <name>         Jump to project with git context
+  gx doctor                Verify installation health
   gx config                Show config
   gx config set <key> <v>  Set config value
   gx init                  Scaffold .claude/ agent config

--- a/crates/gx/tests/snapshots/shell_init_bash.snap
+++ b/crates/gx/tests/snapshots/shell_init_bash.snap
@@ -30,7 +30,7 @@ gx() {
                 return 1
             fi
             ;;
-        ls|recent|rebuild|config|open|init|index|shell-init|--help|-h|--version|-v)
+        ls|recent|rebuild|config|open|init|index|doctor|shell-init|--help|-h|--version|-v)
             "$_GX_BIN" "$@"
             ;;
         resolve)
@@ -66,13 +66,13 @@ _gx_completions() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     if [ "$COMP_CWORD" -eq 1 ]; then
-        local commands="clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v"
+        local commands="clone ls recent resume rebuild config resolve open init index doctor shell-init --help --version -h -v"
         local projects
         projects=$("$_GX_BIN" resolve --list 2>/dev/null)
         COMPREPLY=($(compgen -W "$commands $projects" -- "$cur"))
     elif [ "$COMP_CWORD" -eq 2 ]; then
         case "${COMP_WORDS[1]}" in
-            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|shell-init|--help|--version|-h|-v)
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|doctor|shell-init|--help|--version|-h|-v)
                 if [ "${COMP_WORDS[1]}" = "config" ]; then
                     COMPREPLY=($(compgen -W "set" -- "$cur"))
                 fi

--- a/crates/gx/tests/snapshots/shell_init_fish.snap
+++ b/crates/gx/tests/snapshots/shell_init_fish.snap
@@ -26,7 +26,7 @@ function gx
             else
                 return 1
             end
-        case ls recent rebuild config open init index shell-init --help -h --version -v resolve
+        case ls recent rebuild config open init index doctor shell-init --help -h --version -v resolve
             $_GX_BIN $argv
         case ''
             $_GX_BIN --help
@@ -50,10 +50,10 @@ end
 
 # Tab completion
 complete -c gx -f
-complete -c gx -n "__fish_use_subcommand" -a "clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v"
+complete -c gx -n "__fish_use_subcommand" -a "clone ls recent resume rebuild config resolve open init index doctor shell-init --help --version -h -v"
 complete -c gx -n "__fish_use_subcommand" -a "($_GX_BIN resolve --list 2>/dev/null)"
 complete -c gx -n "__fish_seen_subcommand_from config" -a "set"
 complete -c gx -n "__fish_seen_subcommand_from config; and __fish_seen_subcommand_from set" -a "projectDir defaultHost structure shallow similarityThreshold editor"
-complete -c gx -n "not __fish_seen_subcommand_from clone ls recent resume rebuild config resolve open init index shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt"
+complete -c gx -n "not __fish_seen_subcommand_from clone ls recent resume rebuild config resolve open init index doctor shell-init --help -h --version -v; and test (count (commandline -opc)) -eq 2" -a "wt"
 
 ---- stderr ----

--- a/crates/gx/tests/snapshots/shell_init_zsh.snap
+++ b/crates/gx/tests/snapshots/shell_init_zsh.snap
@@ -30,7 +30,7 @@ gx() {
                 return 1
             fi
             ;;
-        ls|recent|rebuild|config|open|init|index|shell-init|--help|-h|--version|-v)
+        ls|recent|rebuild|config|open|init|index|doctor|shell-init|--help|-h|--version|-v)
             "$_GX_BIN" "$@"
             ;;
         resolve)
@@ -63,14 +63,14 @@ gx() {
 # Tab completion
 _gx() {
     local -a commands projects
-    commands=(clone ls recent resume rebuild config resolve open init index shell-init --help --version -h -v)
+    commands=(clone ls recent resume rebuild config resolve open init index doctor shell-init --help --version -h -v)
 
     if (( CURRENT == 2 )); then
         projects=($("$_GX_BIN" resolve --list 2>/dev/null))
         compadd "${commands[@]}" "${projects[@]}"
     elif (( CURRENT == 3 )); then
         case "${words[2]}" in
-            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|shell-init|--help|--version|-h|-v)
+            clone|ls|recent|resume|rebuild|config|resolve|open|init|index|doctor|shell-init|--help|--version|-h|-v)
                 if [[ "${words[2]}" == "config" ]]; then
                     compadd set
                 fi

--- a/plans/modules/15-distribution.aps.md
+++ b/plans/modules/15-distribution.aps.md
@@ -35,14 +35,26 @@ Make `gx` trivial to install and upgrade for first-time users.
 
 ## Implementation Notes
 
-`install.sh` handles basic installation (checksum/signature verification is not yet implemented — see DIST-4):
+`install.sh` handles installation with release checksum verification:
 
 - Downloads prebuilt binaries from GitHub Releases with OS/arch detection
-- Falls back to building from source via bun if no binary available
+- Verifies downloaded binaries against the release `SHA256SUMS` manifest before installing
+- Errors with manual Cargo build guidance if no binary is available for the detected target
 - Detects and installs shell integration into `.zshrc`, `.bashrc`, or Fish config
 - Ensures `~/.local/bin` is on PATH
 
 CI pipeline (`.github/workflows/ci.yml`) runs tests and builds on both `ubuntu-latest` and `macos-latest`.
+
+Release pipeline (`.github/workflows/release.yml`) builds the Rust binary for `linux-x64`, `linux-aarch64`, `darwin-x64`, and `darwin-aarch64`, uploads `SHA256SUMS`, and emits GitHub artifact attestations for the release assets and checksum manifest.
+
+Trust model: the installer trusts GitHub Releases as the distribution channel, verifies each downloaded binary against the co-published `SHA256SUMS` manifest, and relies on GitHub artifact attestations from the release workflow for build provenance. Users who do not match a prebuilt target are directed to build from source with Cargo.
+
+`gx doctor` reports installation health without mutating user state:
+
+- Runtime and `gx` binary availability on `PATH`
+- Config, project directory, and index paths
+- Indexed project count plus stale path count
+- Shell integration presence for zsh, bash, or fish
 
 ## Ready Checklist
 
@@ -52,7 +64,7 @@ CI pipeline (`.github/workflows/ci.yml`) runs tests and builds on both `ubuntu-l
 
 ## Work Items
 
-- [x] DIST-1: Create `install.sh` curl installer with OS/arch detection and source fallback
+- [x] DIST-1: Create `install.sh` curl installer with OS/arch detection and source-build guidance
 - [x] DIST-2: CI pipeline for Linux and macOS builds
-- [ ] DIST-3: Implement `gx doctor` health check command
-- [ ] DIST-4: Release signing and checksum verification
+- [x] DIST-3: Implement `gx doctor` health check command
+- [x] DIST-4: Release signing and checksum verification

--- a/plans/modules/15-distribution.aps.md
+++ b/plans/modules/15-distribution.aps.md
@@ -67,4 +67,4 @@ Trust model: the installer trusts GitHub Releases as the distribution channel, v
 - [x] DIST-1: Create `install.sh` curl installer with OS/arch detection and source-build guidance
 - [x] DIST-2: CI pipeline for Linux and macOS builds
 - [x] DIST-3: Implement `gx doctor` health check command
-- [x] DIST-4: Release signing and checksum verification
+- [x] DIST-4: Release checksum verification (SHA256SUMS) and GitHub build provenance attestations


### PR DESCRIPTION
## Summary

- Adds `gx doctor`, a read-only installation health check that reports binary availability, shell integration, config/index paths, and stale index entries
- Documents the command in README and wires it into the CLI help surface
- Marks DIST-3 complete in the distribution APS module

## Test plan

- [x] `cargo test --workspace` — 171 tests pass (including new `snapshot_doctor_missing_paths`)
- [x] `cargo clippy --all-targets --workspace -- -D warnings` (via CI)
- [ ] Manual: run `gx doctor` on a machine with and without shell integration configured