### PR TITLE
docs: specify experimental workspaces

### DIFF
--- a/docs/specs/experimental-workspaces.md
+++ b/docs/specs/experimental-workspaces.md
@@ -1,0 +1,394 @@
+# Experimental Workspaces
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-07-26 |
+| Owner | @joshuaboys |
+| Related | `plans/modules/22-experimental-workspaces.aps.md`, `plans/modules/13-tui.aps.md`, `plans/modules/09-tracking.aps.md` |
+| Inspiration | [tobi/try](https://github.com/tobi/try) |
+
+## Summary
+
+Experimental Workspaces extends `gx` from a Git project manager into a workspace lifecycle manager.
+
+Today, `gx` is optimised for permanent repositories: clone them into a structured hierarchy, index them, and return to them quickly. Developers also create short-lived experiments, spikes, throwaway clones and worktrees. Those workspaces commonly end up under `/tmp`, on the desktop, or in vaguely named directories that are difficult to find, assess or clean up later.
+
+The feature introduces `gx try`, a deliberately lightweight surface for creating, finding, promoting and safely removing experimental workspaces. Experiments remain part of the same `gx` index and navigation model as permanent projects, but carry explicit lifecycle metadata and live in a separately configured directory.
+
+The intended user journey is:
+
+> Start an idea with almost no ceremony, find it again instantly, and promote it without losing context if it becomes real.
+
+## Goals
+
+- Create a named experiment and enter it with one command.
+- Support empty directories, cloned repositories and worktrees.
+- Keep experiments organised with predictable, date-prefixed names.
+- Make experiments discoverable through fuzzy search and recorded recency.
+- Allow an experiment to become a permanent project without copying files.
+- Provide guarded clean-up that understands Git and worktree state.
+- Reuse `gx` configuration, indexing, shell integration, URL parsing, cloning and tracking.
+- Preserve compatibility with existing configuration and index files.
+- Work consistently across supported shells and operating systems.
+
+## Non-goals
+
+- A general-purpose temporary-file manager.
+- Automatic deletion based only on age.
+- Running arbitrary project hooks when an experiment is entered.
+- Replacing dedicated Git worktree tools such as Worktrunk.
+- Synchronising experiment content to a hosted service.
+- Treating experiments as lower-quality or ungoverned projects.
+- Adding a separate experiment database or independent navigation system.
+
+## Terminology
+
+| Term | Meaning |
+| --- | --- |
+| Project | A permanent, indexed workspace in the configured project hierarchy. |
+| Experiment | A workspace created under the configured experiment directory and intended to be provisional. It may or may not be a Git repository. |
+| Experimental worktree | An experiment backed by a Git worktree from another indexed or local repository. |
+| Promotion | Moving an experiment into the permanent project hierarchy and changing its indexed kind without copying its contents. |
+| Clean-up | Explicit, guarded removal of one or more experiments. |
+
+`gx try` is the user-facing command. Internally, the domain term is `experiment` so configuration and data structures remain unambiguous.
+
+## User Experience
+
+### Create an empty experiment
+
+```sh
+gx try redis-pool
+```
+
+Creates and enters:
+
+```text
+~/Projects/tries/2026-07-26-redis-pool
+```
+
+If the name already exists, `gx` selects the next available name:
+
+```text
+2026-07-26-redis-pool-2
+2026-07-26-redis-pool-3
+```
+
+### Browse experiments
+
+```sh
+gx try
+```
+
+Opens an interactive experiment selector. Entries are filtered as the user types and ordered using fuzzy relevance with a bounded recency boost.
+
+The selector supports:
+
+- Arrow keys or `Ctrl+P` and `Ctrl+N` to navigate.
+- Enter to select.
+- `/` or direct typing to filter.
+- `r` to rename.
+- `p` to promote.
+- Space to mark for clean-up.
+- Escape or `q` to exit.
+
+An unmatched, non-empty query offers to create a new experiment with that name.
+
+### Clone into an experiment
+
+```sh
+gx try clone tobi/try
+gx try clone https://github.com/tobi/try.git ruby-cli
+```
+
+The existing `gx` URL parser, clone behaviour and authentication environment are reused. With no explicit name, the default includes the repository owner and name:
+
+```text
+2026-07-26-tobi-try
+```
+
+### Create an experimental worktree
+
+```sh
+gx try . auth-spike
+gx try worktree auth-spike
+gx try worktree gx auth-spike
+```
+
+The first two forms use the current repository. The third resolves `gx` through the index.
+
+The implementation must create the worktree through a Git-aware backend. It may use Worktrunk when configured and available, with native `git worktree` as the portable baseline. The resulting index entry records its source repository so later promotion and clean-up use worktree-aware operations.
+
+An experimental worktree must not leave commits reachable only through a detached `HEAD`. The backend must either create a named branch or prove that the checked-out commit remains reachable before destructive clean-up.
+
+### Jump directly to an experiment
+
+```sh
+gx try redis
+```
+
+Resolution order:
+
+1. Exact experiment name or alias.
+2. High-confidence fuzzy match.
+3. Interactive disambiguation when several matches remain.
+4. Offer to create a new experiment when there is no suitable match.
+
+The existing global command remains unchanged:
+
+```sh
+gx redis
+```
+
+It may resolve any indexed workspace, including an experiment, subject to the normal ambiguity rules.
+
+### Rename an experiment
+
+```sh
+gx try rename redis-pool redis-cache
+```
+
+Rename updates the directory and index atomically from the user's perspective. Date prefixes are retained unless the user supplies an explicitly dated name. Git worktrees are moved through `git worktree move` or the selected worktree backend.
+
+### Promote an experiment
+
+```sh
+gx try promote redis-pool
+gx try promote redis-pool --owner joshuaboys
+```
+
+Promotion:
+
+1. Resolves the experiment and checks the destination.
+2. Removes the date prefix from the proposed permanent name.
+3. Previews the source, destination and any Git implications.
+4. Moves the directory using a worktree-aware operation when required.
+5. Changes the index entry from `experiment` or `worktree` to `project`.
+6. Preserves creation and visit history.
+7. Enters the promoted project.
+
+No compatibility symlink is left in the experiment directory. The index is the source of discovery, so retaining a symlink would create duplicate paths and complicate clean-up.
+
+### Clean up experiments
+
+```sh
+gx try clean
+gx try clean --older-than 30d
+gx try clean redis-pool
+```
+
+Age filters select candidates; they never authorise deletion by themselves. The user must confirm the final set.
+
+Before removal, `gx` classifies every candidate:
+
+| State | Default action |
+| --- | --- |
+| Empty or non-Git experiment | Eligible after confirmation. |
+| Clean Git repository with no unique local commits | Eligible after confirmation. |
+| Dirty repository or untracked files | Refuse and explain. |
+| Branch with commits not present on a configured remote | Refuse and explain. |
+| Detached commits that may become unreachable | Refuse and explain. |
+| Registered worktree | Remove through the Git-aware backend. |
+| Promoted project or ordinary indexed project | Never eligible. |
+| Path outside the configured experiment directory | Never eligible. |
+
+`--force` may bypass Git-state refusals only after an additional explicit confirmation. It must not bypass path containment or workspace-kind checks.
+
+Recoverable operating-system deletion should be preferred where supported. If only permanent deletion is available, the confirmation must state that clearly.
+
+## Workspace Model
+
+The current index is extended rather than replaced.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkspaceKind {
+    Project,
+    Experiment,
+    Worktree,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexEntry {
+    pub path: String,
+    pub url: String,
+    pub cloned_at: String,
+    pub last_visited: Option<String>,
+    pub kind: Option<WorkspaceKind>,
+    pub created_at: Option<String>,
+    pub source_project: Option<String>,
+    pub disposable: Option<bool>,
+}
+```
+
+Compatibility rules:
+
+- An entry without `kind` is a `project`.
+- `createdAt` is the canonical creation time for new workspaces.
+- Existing entries fall back to `clonedAt` when `createdAt` is absent.
+- `sourceProject` is present only when lifecycle operations need to find an originating repository.
+- Optional fields are omitted when not applicable, preserving readable JSON and avoiding a mandatory migration.
+- Existing `gx` commands continue to accept the old schema.
+
+The index may retain its current name key for the first implementation. Any collision must be surfaced rather than silently overwriting another workspace. A future schema migration may introduce stable workspace IDs if rename and cross-root collision handling prove that necessary.
+
+## Configuration
+
+Add one backwards-compatible field:
+
+```json
+{
+  "projectDir": "~/Projects/src",
+  "experimentDir": "~/Projects/tries"
+}
+```
+
+`experimentDir` defaults to `~/Projects/tries`. The value can be changed with:
+
+```sh
+gx config set experimentDir ~/code/experiments
+```
+
+The experiment directory is independent of the permanent project structure setting. Experiments always use a flat, date-prefixed layout because they are provisional and are primarily found through `gx`, not by traversing owner directories.
+
+## Naming
+
+- Generated directory format: `YYYY-MM-DD-<slug>`.
+- Slugs accept letters, numbers, `_`, `-` and `.`.
+- Whitespace is normalised to `-`.
+- Path separators, `.` and `..` segments, control characters and empty names are rejected.
+- A collision with a trailing number increments that number.
+- Other collisions append `-2`, then increment.
+- Display may omit the date prefix, but stored names and paths remain exact.
+
+## Discovery and Ranking
+
+The current Jaro-Winkler implementation remains the textual similarity source. Experiment ranking adds a bounded recency adjustment derived from indexed `lastVisited`; it must not rely on directory modification time.
+
+Exact matches always win. Recency must never make a weak textual match auto-jump to an unrelated workspace. The existing similarity and auto-jump thresholds remain safety boundaries until benchmarks justify changing them.
+
+The ranking function must be deterministic for a fixed query and index state and covered by table-driven tests.
+
+## TUI Integration
+
+Experimental Workspaces should not create an unrelated TUI architecture.
+
+- `gx try` launches the generic selector filtered to experiment and experimental-worktree kinds.
+- `gx tui` shows all workspace kinds.
+- Dashboard data provides Git state when available.
+- Tracking provides recency.
+- Lifecycle actions are enabled according to workspace kind.
+
+The TUI module should be revised so selection, filtering and lifecycle actions operate on a shared `WorkspaceView` model. Git details may load progressively, but navigation and exit must never block on a slow repository.
+
+## Shell Contract
+
+Like `gx clone` and `gx resolve`, successful commands that change directory emit the final path to stdout for the shell wrapper. Diagnostics, previews and warnings go to stderr.
+
+Shell integration must support:
+
+- zsh
+- bash
+- fish
+- PowerShell once the Windows module lands
+
+All emitted paths must use shell-appropriate quoting. The core command must never assume a POSIX shell when constructing lifecycle operations.
+
+## Failure and Recovery
+
+Operations that change both the filesystem and index use a recoverable sequence:
+
+1. Validate all paths and Git preconditions.
+2. Calculate the intended index mutation without saving it.
+3. Perform the filesystem or worktree operation.
+4. Save the index atomically.
+5. If the index save fails, attempt to move the workspace back and report both the primary and rollback outcomes.
+
+Clean-up is the exception because deletion may not be reversible. The index entry is removed only after deletion succeeds. If deletion succeeds and index persistence fails, `gx doctor` must be able to identify and prune the missing entry.
+
+No operation silently overwrites an existing destination.
+
+## Security and Safety Invariants
+
+- Canonicalise source, destination and configured roots before mutation.
+- Never remove a path unless it is contained by the canonical experiment root.
+- Never follow a symlink to authorise deletion outside the experiment root.
+- Never treat age as deletion approval.
+- Never delete an ordinary project through `gx try clean`.
+- Never discard dirty files or unique commits without an explicit force path.
+- Never interpolate user-controlled paths into an unevaluated shell string.
+- Invoke Git and worktree tools with structured process arguments.
+- Record enough context in errors for the user to recover manually.
+
+## Observability
+
+`gx doctor` should report:
+
+- Whether `experimentDir` exists and is writable.
+- Indexed experiments whose paths are missing.
+- Directories under `experimentDir` that are not indexed.
+- Worktree entries whose source repository cannot be resolved.
+- Entries whose kind and physical Git state disagree.
+- Promoted entries that still point inside `experimentDir`.
+
+`gx try ls --json` should expose stable machine-readable output for agent and scripting use without requiring the TUI.
+
+## Accessibility
+
+- All TUI actions have visible keyboard hints.
+- Colour is never the only indicator of workspace kind, selection or deletion state.
+- `NO_COLOR` and non-TTY output are respected.
+- Every interactive operation has a non-interactive CLI equivalent.
+- Destructive confirmation is readable by screen readers and usable without function keys.
+
+## Rollout
+
+### Phase 1: Domain foundation
+
+Add workspace kinds, `experimentDir`, compatible index loading and experiment indexing.
+
+### Phase 2: Core creation
+
+Ship empty experiment creation, direct resolution, date naming and collision handling.
+
+### Phase 3: Git-backed experiments
+
+Ship experimental clones and worktrees with provenance metadata.
+
+### Phase 4: Lifecycle
+
+Ship rename, promotion, safety inspection and clean-up.
+
+### Phase 5: Interactive experience
+
+Ship the shared TUI selector and lifecycle actions.
+
+## Acceptance Scenarios
+
+1. An existing index created by the current release loads without modification and every entry behaves as a project.
+2. `gx try redis` creates a dated experiment, indexes it, records the visit and enters it.
+3. Repeating the same creation produces a non-conflicting, deterministically versioned name.
+4. `gx try clone tobi/try` reuses normal clone authentication and creates an experiment entry.
+5. `gx try . auth-spike` creates a registered worktree that can be found from both `gx try` and global navigation.
+6. Promoting a normal experiment moves it, preserves history and leaves no duplicate experiment entry.
+7. Promoting a worktree uses a Git-aware move and leaves `git worktree list` consistent.
+8. Clean-up refuses a dirty experiment and explains the blocking files.
+9. Clean-up refuses an experimental branch with unique local commits.
+10. Clean-up cannot remove a symlink target or path outside `experimentDir`.
+11. A non-interactive caller can list, create, promote and inspect experiments without parsing ANSI output.
+12. Existing clone, resolve, recent, resume and shell-integration snapshots remain unchanged unless deliberately extended.
+
+## Open Questions
+
+- Should the first release expose `gx try clean --force`, or require manual Git recovery for every unsafe state?
+- Should native Git or Worktrunk be the default worktree backend when both are installed?
+- Should `gx recent` include experiments by default or require `--all`?
+- Is a stable workspace ID required in the first schema extension, or can name-keyed entries remain until a later migration?
+- Which recoverable deletion mechanisms can be supported consistently without compromising the single-binary goal?
+
+## Attribution
+
+The dated experiment directory, recency-oriented selector, disposable worktree, rename, promotion and guarded clean-up concepts are inspired by [`tobi/try`](https://github.com/tobi/try), licensed under MIT. `gx` should add it to the README acknowledgements when this feature becomes user-facing.

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -54,7 +54,7 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - [ ] `gx doctor` and index diagnostics/stats for trust at scale
 - [ ] Native Windows support — release binary, PowerShell integration, installer (see Windows Support module)
 
-### v6 — Workspace Lifecycle (Draft)
+### v6: Workspace Lifecycle (Draft)
 
 - [ ] `gx try <name>` creates and enters a dated experimental workspace
 - [ ] Empty, cloned and worktree-backed experiments share the normal workspace index
@@ -152,4 +152,4 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — _accepted_
 - **D-010:** Port gx to Rust with strict behavior parity, preserving CLI surface, config and index schemas, and `gx shell-init` output (see `decisions/010-rust-port.md`) — _proposed_
 - **D-011:** Keep config/index at `~/.config/gx/` on Windows (no `%APPDATA%` move) — cross-platform path and schema consistency, no migration needed — _proposed_
-- **D-012:** Experiments share the existing index through optional workspace-kind and lifecycle fields; entries without a kind remain permanent projects — _proposed_
+- **D-012:** Experiments share the existing index through optional workspace-kind and lifecycle fields; entries without a kind remain permanent projects. _Proposed._

--- a/plans/index.aps.md
+++ b/plans/index.aps.md
@@ -54,6 +54,15 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - [ ] `gx doctor` and index diagnostics/stats for trust at scale
 - [ ] Native Windows support — release binary, PowerShell integration, installer (see Windows Support module)
 
+### v6 — Workspace Lifecycle (Draft)
+
+- [ ] `gx try <name>` creates and enters a dated experimental workspace
+- [ ] Empty, cloned and worktree-backed experiments share the normal workspace index
+- [ ] `gx try` provides recency-aware interactive discovery without filesystem-mtime heuristics
+- [ ] Experiments can be renamed and promoted into the permanent project hierarchy
+- [ ] Clean-up is restricted by workspace kind, canonical path containment and Git safety inspection
+- [ ] Machine-readable experiment inspection supports scripts and coding agents
+
 ## Constraints
 
 - Rust only (no JS runtime) — superseded the original "TypeScript + Bun only" constraint at the RST-7 cutover (see `decisions/010-rust-port.md`)
@@ -86,6 +95,7 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 | [Fork & Sync](./modules/19-fork.aps.md)                                                   | Fork repos via GitHub, clone locally, and keep forks synced with upstream                     | Draft               | v4      | Clone, Shell Plugin, CLI |
 | [Rust Port](./modules/20-rust-port.aps.md)                                                | Re-implement gx as a Rust binary with full behavior parity                                    | In Progress         | v5      | All                      |
 | [Windows Support](./modules/21-windows.aps.md)                                            | Windows binary, PowerShell shell-init, installer, and doctor awareness                        | Ready               | v5      | Distribution & Install UX, Shell Portability, CLI |
+| [Experimental Workspaces](./modules/22-experimental-workspaces.aps.md)                         | Create, discover, promote and safely clean up provisional directories, clones and worktrees              | Draft               | v6      | Index, Clone, Shell, Tracking, Rust Port |
 
 ## Risks
 
@@ -105,6 +115,9 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 | Fork sync conflicts            | Rebase/merge on diverged forks can produce conflicts        | Abort cleanly, leave tree in resolvable state, print actionable guidance           |
 | Windows shell semantics        | PowerShell quoting/completion differ from POSIX shells      | Snapshot-test shell-init output per shell; dedicated Windows CI job                |
 
+| Destructive experiment clean-up | Valuable local work could be removed | Restrict clean-up to experiment kinds under the canonical experiment root; inspect dirty files and unique commits; require explicit confirmation |
+| Worktree lifecycle drift | Git metadata and indexed paths can disagree | Use Git-aware move/remove operations; retain source provenance; extend doctor diagnostics |
+
 ## Open Questions
 
 - [x] Which language? — TypeScript/Bun
@@ -122,6 +135,10 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - [ ] Which TUI library for interactive mode? (ink, blessed, raw ANSI, or Bun-native)
 - [ ] Should Windows distribution include winget/scoop manifests, or installer + release asset only? (installer-only proposed)
 
+- [ ] Should experimental workspaces appear in unfiltered `gx recent` output by default?
+- [ ] Should Worktrunk or native Git be preferred when both experimental-worktree backends are available?
+- [ ] Should recoverable clean-up add a dependency or use platform capabilities when present?
+
 ## Decisions
 
 - **D-001:** Owner/repo directory structure by default (`owner`), `flat` (repo only) and `host` (host/owner/repo) modes via config — _accepted_
@@ -135,3 +152,4 @@ Cloning and navigating git repositories requires too many steps. `git clone` dum
 - **D-008:** README includes Acknowledgements section crediting ghq and gclone as prior art — _accepted_
 - **D-010:** Port gx to Rust with strict behavior parity, preserving CLI surface, config and index schemas, and `gx shell-init` output (see `decisions/010-rust-port.md`) — _proposed_
 - **D-011:** Keep config/index at `~/.config/gx/` on Windows (no `%APPDATA%` move) — cross-platform path and schema consistency, no migration needed — _proposed_
+- **D-012:** Experiments share the existing index through optional workspace-kind and lifecycle fields; entries without a kind remain permanent projects — _proposed_

--- a/plans/modules/22-experimental-workspaces.aps.md
+++ b/plans/modules/22-experimental-workspaces.aps.md
@@ -1,0 +1,222 @@
+# Experimental Workspaces
+
+| ID | Owner | Status |
+| --- | --- | --- |
+| EXP | @joshuaboys | Draft |
+
+- Version: v6
+- Specification: [Experimental Workspaces](../../docs/specs/experimental-workspaces.md)
+- Inspiration: [tobi/try](https://github.com/tobi/try)
+- Depends on: Index, Clone, Shell Plugin, Tracking, Rust Port
+- Informs: Dashboard, Interactive TUI, Index Reliability & Observability, Windows Support
+
+## Purpose
+
+Give provisional ideas a first-class lifecycle inside `gx`: create an experiment with almost no ceremony, find it again through normal navigation, understand its Git state, promote it when it becomes real, and remove it safely when it does not.
+
+## Outcome
+
+`gx` manages permanent projects and provisional experiments through one compatible workspace index. Users gain a compact `gx try` surface for empty experiments, clones and worktrees without introducing a separate database or duplicating existing clone, fuzzy, tracking and shell behaviour.
+
+## In Scope
+
+- `gx try [query]` creation, resolution and filtered interactive selection
+- Configurable experiment root with date-prefixed, collision-safe naming
+- Empty, cloned and worktree-backed experiments
+- Backwards-compatible workspace-kind and lifecycle metadata in the index
+- Recency-aware experiment discovery using indexed visits
+- Rename and promotion into the permanent project hierarchy
+- Git-aware, path-contained clean-up with explicit confirmation
+- Non-interactive list and inspection output for scripting and agents
+- Shared selector model that can also underpin the future all-workspace TUI
+- Doctor diagnostics for missing, orphaned and inconsistent experiments
+- Cross-platform command and path contracts
+
+## Out of Scope
+
+- Automatic age-based deletion
+- Hosted experiment synchronisation
+- Arbitrary commands or hooks on experiment entry
+- Git commit, push, pull or merge operations from the selector
+- Replacing Worktrunk or exposing every worktree-management feature
+- A second index dedicated to experiments
+- Compatibility symlinks after promotion
+
+## Interfaces
+
+**Depends on:**
+
+- Index for compatible persistence, lookup and atomic writes
+- Clone and URL parsing for repository-backed experiments
+- Shell Plugin for parent-shell directory changes
+- Tracking for `lastVisited`
+- Rust Port as the active implementation
+
+**Exposes:**
+
+- `gx try [query]`
+- `gx try clone <repo> [name]`
+- `gx try . <name>`
+- `gx try worktree [project] <name>`
+- `gx try ls [--json]`
+- `gx try rename <experiment> <name>`
+- `gx try promote <experiment>`
+- `gx try clean [experiment] [--older-than <age>]`
+- Workspace kind and experiment provenance for Dashboard, TUI and Doctor
+
+## Design Commitments
+
+1. Existing index entries without a workspace kind remain permanent projects.
+2. Experiments share the normal index, tracking and global navigation path.
+3. `experimentDir` is a separate flat root and defaults to `~/Projects/tries`.
+4. Filesystem modification time is not visit history; discovery uses indexed `lastVisited`.
+5. Promotion moves and reclassifies the workspace without leaving a symlink.
+6. Clean-up never targets ordinary projects and never relies on age as authorisation.
+7. Worktree promotion and removal use Git-aware operations.
+8. Interactive features always have a non-interactive equivalent.
+9. User-controlled paths are passed as process arguments, never interpolated into shell commands.
+
+## Ready Checklist
+
+Change status to **Ready** when:
+
+- [x] Purpose and product boundary are documented
+- [x] Initial command surface is specified
+- [x] Backwards-compatible index direction is specified
+- [x] Safety invariants are specified
+- [x] Dependencies and consumers are identified
+- [x] Work items and validation outcomes are defined
+- [ ] Open questions in the specification have owner decisions
+- [ ] Human review accepts the command name, schema fields and clean-up policy
+
+## Work Items
+
+### EXP-001: Workspace kinds and experiment configuration
+
+- **Intent:** Represent provisional workspaces without breaking existing users.
+- **Expected Outcome:** Add `experimentDir` and optional workspace lifecycle fields; existing configuration and index fixtures continue to load byte-for-byte where no new data is written.
+- **Validation:** Unit tests load old fixtures as `project`; config tests prove the default and custom experiment roots; snapshot tests for existing commands remain unchanged.
+
+### EXP-002: Experiment creation and direct navigation
+
+- **Intent:** Make starting an organised experiment a one-command operation.
+- **Expected Outcome:** `gx try <name>` creates a date-prefixed directory, indexes and touches it, prints the final path for shell integration, and resolves existing experiment queries instead of duplicating them.
+- **Validation:** Integration tests cover first creation, exact resolution, fuzzy resolution, ambiguous matches, invalid names and non-TTY output.
+- **Dependencies:** EXP-001
+
+### EXP-003: Deterministic naming and collision handling
+
+- **Intent:** Preserve zero-ceremony creation without overwriting or confusing existing experiments.
+- **Expected Outcome:** Names are slugged consistently; repeated names receive predictable numeric suffixes; every candidate path is contained by the experiment root.
+- **Validation:** Table-driven tests cover whitespace, Unicode policy, trailing numbers, existing destinations, traversal attempts, separators and canonical-path containment.
+- **Dependencies:** EXP-001
+
+### EXP-004: Experimental clone flow
+
+- **Intent:** Let users inspect or modify a repository provisionally without placing it among permanent projects.
+- **Expected Outcome:** `gx try clone <repo> [name]` reuses normal URL parsing and Git authentication, creates the clone under `experimentDir`, and records experiment metadata and origin URL.
+- **Validation:** Integration tests use local bare repositories for shorthand-derived names, explicit names, clone failure rollback and index persistence.
+- **Dependencies:** EXP-001, EXP-003
+
+### EXP-005: Experimental worktree flow
+
+- **Intent:** Give repository spikes an isolated, disposable worktree with enough provenance for safe lifecycle operations.
+- **Expected Outcome:** Current-directory and indexed-project forms create a registered worktree, record its source, avoid unreachable detached commits, and enter it through the shell contract.
+- **Validation:** Tests assert `git worktree list` consistency, branch reachability, source resolution, collision handling and rollback after a failed index save.
+- **Dependencies:** EXP-001, EXP-003
+
+### EXP-006: Machine-readable list and inspection
+
+- **Intent:** Make the lifecycle usable by scripts and coding agents without scraping the TUI.
+- **Expected Outcome:** `gx try ls` provides stable human output and `gx try ls --json` exposes workspace kind, path, age, source and a Git-safety summary.
+- **Validation:** Snapshot human output; schema-test JSON output; confirm colour and terminal control codes never appear in JSON.
+- **Dependencies:** EXP-001
+
+### EXP-007: Shared interactive selector
+
+- **Intent:** Provide fast fuzzy navigation while avoiding a one-off experiment TUI.
+- **Expected Outcome:** A reusable workspace selector supports filtering, recency display, responsive terminal layout and selection; `gx try` applies an experiment-kind filter and the future `gx tui` can reuse the same component.
+- **Validation:** State-machine tests cover navigation, editing, resize, cancel, exact selection, create-new selection and non-colour presentation.
+- **Dependencies:** EXP-002, EXP-006
+
+### EXP-008: Rename lifecycle
+
+- **Intent:** Let an experiment's name evolve without losing history or corrupting registered worktrees.
+- **Expected Outcome:** Rename preflights the destination, performs a normal or worktree-aware move, updates the index, preserves timestamps and rolls back when persistence fails.
+- **Validation:** Tests cover normal directories, Git repositories, worktrees, destination collisions and simulated index-write failure.
+- **Dependencies:** EXP-003, EXP-005
+
+### EXP-009: Promotion lifecycle
+
+- **Intent:** Turn a successful experiment into a permanent project without copying it or leaving duplicate discovery paths.
+- **Expected Outcome:** Promotion previews and moves the workspace, removes the date prefix by default, respects the configured project structure, reclassifies the index entry, preserves history and leaves no compatibility symlink.
+- **Validation:** End-to-end tests cover empty directories, regular repositories, worktrees, destination collision, rollback and subsequent global resolution.
+- **Dependencies:** EXP-005, EXP-008
+
+### EXP-010: Safe clean-up engine
+
+- **Intent:** Make abandoned experiments removable without normalising destructive repository loss.
+- **Expected Outcome:** Candidate inspection classifies dirty files, untracked content, unique commits, detached reachability, worktree registration and path containment; only explicitly confirmed eligible experiments are removed.
+- **Validation:** Adversarial tests cover symlinks, `..`, changed roots, dirty repos, untracked files, unpushed branches, detached commits, ordinary projects and current-working-directory removal.
+- **Dependencies:** EXP-004, EXP-005, EXP-006
+
+### EXP-011: Interactive lifecycle actions
+
+- **Intent:** Make rename, promotion and multi-select clean-up available without sacrificing the command-line safety contracts.
+- **Expected Outcome:** Selector actions delegate to the same preflight and mutation services as non-interactive commands and present complete previews and refusals.
+- **Validation:** State-machine and integration tests prove the TUI cannot bypass lifecycle guards or path containment.
+- **Dependencies:** EXP-007, EXP-008, EXP-009, EXP-010
+
+### EXP-012: Doctor, documentation and attribution
+
+- **Intent:** Make the feature diagnosable, discoverable and explicit about its inspiration.
+- **Expected Outcome:** `gx doctor` reports missing, orphaned and inconsistent experiments; README and use cases cover the workflow; acknowledgements credit `tobi/try`.
+- **Validation:** Doctor fixtures cover every diagnostic class; documentation examples match CLI snapshots; links and acknowledgements are present.
+- **Dependencies:** EXP-006, EXP-009, EXP-010
+
+### EXP-013: Cross-platform lifecycle verification
+
+- **Intent:** Preserve the single-binary and multi-shell promise across lifecycle operations.
+- **Expected Outcome:** Paths, process invocation, worktree operations and shell output work on Linux, macOS and Windows/PowerShell when the Windows module is available.
+- **Validation:** CI runs the applicable experiment suite on all supported operating systems; shell-init snapshots cover every supported shell.
+- **Dependencies:** EXP-002 through EXP-012, Windows Support
+
+## Execution Order
+
+1. Foundation: EXP-001, EXP-003
+2. Core surface: EXP-002, EXP-004, EXP-005, EXP-006
+3. Lifecycle: EXP-008, EXP-009, EXP-010
+4. Interactive surface: EXP-007, EXP-011
+5. Hardening and adoption: EXP-012, EXP-013
+
+The selector may be prototyped alongside the core surface, but destructive interactive actions must not land before the shared lifecycle services and guards.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Clean-up removes valuable work | Severe and potentially irreversible | Restrict by kind and canonical root; inspect Git state; explicit confirmation; refuse unsafe states by default |
+| Worktree metadata becomes inconsistent | Git commands fail or leave orphan registrations | Use Git-aware move/remove; verify with `git worktree list`; doctor diagnostics |
+| Optional index fields become an accidental migration | Existing installations fail to load or rewrite unexpectedly | Serde defaults and omission; old-fixture tests; no eager rewrite |
+| Recency causes an incorrect auto-jump | User enters or mutates the wrong workspace | Exact match priority; bounded boost; retain textual auto-jump threshold |
+| The experiment TUI diverges from the planned global TUI | Duplicate terminal code and inconsistent behaviour | Shared `WorkspaceView` and selector state model |
+| Permanent and provisional workspaces become conceptually blurred | Users accidentally treat projects as disposable | Explicit kind, separate root, destructive actions restricted to experiments |
+| Cross-platform deletion and quoting differ | Safety or reliability regression on Windows | Structured process arguments, platform tests, recoverable deletion capability detection |
+
+## Open Questions
+
+- [ ] EXP-Q001: Ship `--force` clean-up in the first release or defer it?
+- [ ] EXP-Q002: Prefer native Git or Worktrunk when both worktree backends are available?
+- [ ] EXP-Q003: Include experiments in unfiltered `gx recent` by default?
+- [ ] EXP-Q004: Add stable workspace IDs now or retain name-keyed index entries initially?
+- [ ] EXP-Q005: Which recoverable deletion backends preserve the single-binary distribution goal?
+
+## Completion Criteria
+
+- The twelve acceptance scenarios in the specification pass.
+- Existing configuration and index fixtures remain compatible.
+- Existing command snapshots change only where the new surface is intentionally exposed.
+- No destructive path can target an ordinary project or escape `experimentDir`.
+- Worktree creation, promotion and clean-up leave Git metadata consistent.
+- Interactive and non-interactive operations share the same lifecycle services.
+- Documentation demonstrates the complete idea-to-project journey.


### PR DESCRIPTION
## Summary

Adds the product and technical specification for Experimental Workspaces, a `gx try` lifecycle for provisional directories, cloned repositories and worktrees.

Updates the APS roadmap with a new v6 Workspace Lifecycle outcome and a delivery module covering the compatible index extension, creation flows, Git-backed experiments, promotion, guarded clean-up, shared TUI integration, diagnostics and cross-platform verification.

## Why

`gx` already owns structured cloning, fuzzy navigation, shell auto-cd and visit tracking. Developers also create short-lived experiments that are easy to lose and risky to clean up manually. This proposal makes those workspaces first-class without adding a second index or duplicating existing primitives.

The design is inspired by `tobi/try`, with changes for the stronger `gx` index, Git safety model, project promotion and cross-platform direction.

## Product and developer impact

- Introduces the proposed `gx try` command family.
- Extends the existing index through optional, backwards-compatible workspace lifecycle fields.
- Defines safe promotion without compatibility symlinks.
- Restricts clean-up by workspace kind, canonical root and Git state.
- Reframes the future TUI as a shared workspace selector rather than a separate experiment interface.
- Provides 13 independently verifiable APS work items and an explicit execution order.

## Files

- `docs/specs/experimental-workspaces.md`
- `plans/modules/22-experimental-workspaces.aps.md`
- `plans/index.aps.md`

## Validation

- Verified the branch is based directly on current `main` and contains only the three intended documentation files.
- Verified the specification and module links and headings.
- Verified the APS index contains exactly one v6 section, module row, D-012 decision and clean-up risk.
- No runtime checks were run because this PR changes documentation and planning only.

## Review focus

- `gx try` as the command name.
- Initial optional index fields versus introducing stable workspace IDs immediately.
- Native Git versus Worktrunk backend preference.
- Whether forced clean-up belongs in the first release.
- Recoverable deletion without compromising the single-binary goal.